### PR TITLE
Add sim_interface to StableSwap pools

### DIFF
--- a/crvusdsim/network/subgraph.py
+++ b/crvusdsim/network/subgraph.py
@@ -361,8 +361,8 @@ async def _stableswap_snapshot(pool_addresses):
                 "rates": [
                     10 ** (18 - int(decimals)) for decimals in r["pool"]["coinDecimals"]
                 ],
-                "fee": int(float(r["fee"]) * 1e18),
-                "admin_fee": int(float(r["adminFee"]) * 1e18),
+                "fee": int(float(r["fee"]) * 1e10),
+                "admin_fee": int(float(r["adminFee"]) * 1e10),
                 "name": r["pool"]["name"],
                 "symbol": r["pool"]["symbol"],
                 "decimals": 18,

--- a/crvusdsim/pool/__init__.py
+++ b/crvusdsim/pool/__init__.py
@@ -14,7 +14,7 @@ from crvusdsim.pool.crvusd.price_oracle.aggregate_stable_price import (
 from crvusdsim.pool.crvusd.price_oracle.price_oracle import PriceOracle
 from crvusdsim.pool.crvusd.stabilizer.peg_keeper import PegKeeper
 from crvusdsim.pool.crvusd.stablecoin import StableCoin
-from crvusdsim.pool.crvusd.stableswap import CurveStableSwapPool
+from crvusdsim.pool.sim_interface.sim_stableswap import SimCurveStableSwapPool
 from crvusdsim.pool.sim_interface.sim_controller import SimController
 from crvusdsim.pool.sim_interface.sim_llamma import SimLLAMMAPool
 from crvusdsim.pool_data import get_metadata
@@ -147,7 +147,7 @@ def get_sim_market(
         pool_kwargs["coins"] = [
             StableCoin(**coin_kwargs) for coin_kwargs in pool_kwargs["coins"]
         ]
-        stableswap_pools.append(CurveStableSwapPool(**pool_kwargs))
+        stableswap_pools.append(SimCurveStableSwapPool(**pool_kwargs))
 
     peg_keepers = [
         PegKeeper(

--- a/crvusdsim/pool/crvusd/stableswap.py
+++ b/crvusdsim/pool/crvusd/stableswap.py
@@ -5,8 +5,10 @@ StableSwap
 """
 
 from collections import defaultdict
-from typing import List, Tuple
+from typing import List, Tuple, Type
 
+from curvesim.pool.base import Pool
+from curvesim.pool.snapshot import CurvePoolBalanceSnapshot, Snapshot
 from curvesim.pool.stableswap.pool import CurvePool
 from crvusdsim.pool.crvusd.stablecoin import StableCoin
 from crvusdsim.pool.crvusd.clac import exp, shift
@@ -21,7 +23,10 @@ ADMIN_FEE = 5000000000
 LP_PROVIDER = "LP_PROVIDER"
 
 
-class CurveStableSwapPool(BlocktimestampMixins):
+class CurveStableSwapPool(Pool, BlocktimestampMixins):
+
+    snapshot_class: Type[Snapshot] = CurvePoolBalanceSnapshot
+
     __slots__ = (
         "address",
         "name",

--- a/crvusdsim/pool/sim_interface/sim_stableswap.py
+++ b/crvusdsim/pool/sim_interface/sim_stableswap.py
@@ -1,0 +1,151 @@
+from curvesim.templates import SimAssets
+from curvesim.exceptions import SimPoolError
+from curvesim.templates.sim_pool import SimPool
+from curvesim.utils import cache, override
+from curvesim.pool.sim_interface.asset_indices import AssetIndicesMixin
+from crvusdsim.pool.crvusd.conf import ARBITRAGUR_ADDRESS
+
+from ..crvusd.stableswap import CurveStableSwapPool
+
+
+class SimCurveStableSwapPool(SimPool, AssetIndicesMixin, CurveStableSwapPool):
+    """
+    Class to enable use of CurveStableSwapPool in simulations by exposing
+    a generic interface (`SimPool`).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @property
+    @override
+    @cache
+    def asset_names(self):
+        """Return list of asset names."""
+        return self.coin_names
+
+    @property
+    @override
+    def _asset_balances(self):
+        """Return list of asset balances in same order as asset_names."""
+        return self.balances
+
+    @override
+    def price(self, i, j, use_fee=True):
+        """
+        Returns the spot price of `coin_in` quoted in terms of `coin_out`,
+        i.e. the ratio of output coin amount to input coin amount for
+        an "infinitesimally" small trade.
+
+        Coin IDs should be strings but as a legacy feature integer indices
+        corresponding to the pool implementation are allowed (caveat lector).
+
+        The indices are assumed to include base pool underlyer indices.
+
+        Parameters
+        ----------
+        i : int
+            ID of coin to be priced; in a swapping context, this is
+            the "in"-token.
+        j : int
+            ID of quote currency; in a swapping context, this is the
+            "out"-token.
+        use_fee: bool, default=True
+            Deduct fees.
+
+        Returns
+        -------
+        float
+            Price of `coin_in` quoted in `coin_out`
+        """
+        return self.dydx(i, j, use_fee=use_fee)
+
+    @override
+    def trade(self, i, j, size, user=ARBITRAGUR_ADDRESS):
+        """
+        Perform an exchange between two coins.
+
+        Coin IDs should be strings but as a legacy feature integer indices
+        corresponding to the pool implementation are allowed (caveat lector).
+
+        Note that all amounts are normalized to be in the same units as
+        pool value, e.g. for Curve Stableswap pools, the same units as `D`.
+        This simplifies cross-token comparisons and creation of metrics.
+
+
+        Parameters
+        ----------
+        i : int
+            ID of "in" coin.
+        j : int
+            ID of "out" coin.
+        size : int
+            Amount of coin `i` being exchanged.
+
+        Returns
+        -------
+        (int, int)
+            (amount of coin `j` received, trading fee)
+        """
+        if size == 0:
+            return 0, 0
+        self.coins[i]._mint(user, size)
+        amount_out = self.exchange(i, j, size)
+        return amount_out
+    @override
+    def get_max_trade_size(self, i, j, out_balance_perc=0.01):
+        """
+        Calculate the swap amount of the "in" coin needed to leave
+        the specified percentage of the "out" coin.
+
+        Parameters
+        ----------
+        i : int
+            ID of "in" coin.
+        j : int
+            ID of "out" coin.
+        out_balance_perc : float
+            Percentage of the "out" coin balance that should remain
+            after doing the swap.
+
+        Returns
+        -------
+        int
+            The amount of "in" coin needed.
+        """
+        xp = self._xp()
+        xp_j = int(xp[j] * out_balance_perc)
+
+        in_amount = self.get_y(j, i, xp_j, xp) - xp[i]
+        return in_amount
+
+    @override
+    def get_min_trade_size(self, i):
+        """
+        Return the minimal trade size allowed for the pool.
+
+        Parameters
+        ----------
+        i : int
+            ID of "in" coin.
+
+        Returns
+        -------
+        int
+            The minimal trade size
+        """
+        return 0
+
+    @property
+    @override
+    @cache
+    def assets(self):
+        """
+        Return :class:`.SimAssets` object with the properties of the pool's assets.
+
+        Returns
+        -------
+        SimAssets
+            SimAssets object that stores the properties of the pool's assets.
+        """
+        return SimAssets(self.coin_names, self.coin_addresses, self.chain)

--- a/poetry.lock
+++ b/poetry.lock
@@ -417,6 +417,17 @@ files = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+files = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
 name = "contourpy"
 version = "1.1.0"
 description = "Python library for calculating contours of 2D quadrilateral grids"
@@ -877,6 +888,20 @@ lint = ["black (>=23)", "flake8 (==3.8.3)", "isort (>=5.11.0)", "mypy (==0.971)"
 test = ["hypothesis (>=4.43.0)", "mypy (==0.971)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)", "types-setuptools"]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.1.3"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
+    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "fonttools"
 version = "4.43.1"
 description = "Tools to manipulate font files"
@@ -1089,6 +1114,38 @@ lint = ["black (>=22)", "flake8 (==6.0.0)", "flake8-bugbear (==23.3.23)", "isort
 test = ["eth-utils (>=1.0.1,<3)", "hypothesis (>=3.44.24,<=6.31.6)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)"]
 
 [[package]]
+name = "hypothesis"
+version = "6.90.0"
+description = "A library for property-based testing"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "hypothesis-6.90.0-py3-none-any.whl", hash = "sha256:4d7d3d3d5e4e4a9954b448fc8220cd73573e3e32adb00059f6907de6b55dcd5e"},
+    {file = "hypothesis-6.90.0.tar.gz", hash = "sha256:0ab33900b9362318bd03d911a77a0dda8629c1877420074d87ae466919f6e4c0"},
+]
+
+[package.dependencies]
+attrs = ">=19.2.0"
+exceptiongroup = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+sortedcontainers = ">=2.1.0,<3.0.0"
+
+[package.extras]
+all = ["backports.zoneinfo (>=0.2.1)", "black (>=19.10b0)", "click (>=7.0)", "django (>=3.2)", "dpcontracts (>=0.4)", "lark (>=0.10.1)", "libcst (>=0.3.16)", "numpy (>=1.17.3)", "pandas (>=1.1)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "tzdata (>=2023.3)"]
+cli = ["black (>=19.10b0)", "click (>=7.0)", "rich (>=9.0.0)"]
+codemods = ["libcst (>=0.3.16)"]
+dateutil = ["python-dateutil (>=1.4)"]
+django = ["django (>=3.2)"]
+dpcontracts = ["dpcontracts (>=0.4)"]
+ghostwriter = ["black (>=19.10b0)"]
+lark = ["lark (>=0.10.1)"]
+numpy = ["numpy (>=1.17.3)"]
+pandas = ["pandas (>=1.1)"]
+pytest = ["pytest (>=4.6)"]
+pytz = ["pytz (>=2014.1)"]
+redis = ["redis (>=3.0.0)"]
+zoneinfo = ["backports.zoneinfo (>=0.2.1)", "tzdata (>=2023.3)"]
+
+[[package]]
 name = "idna"
 version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -1097,6 +1154,17 @@ python-versions = ">=3.5"
 files = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
     {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
 
 [[package]]
@@ -1385,6 +1453,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -1800,6 +1878,21 @@ docs = ["furo", "olefile", "sphinx (>=2.4)", "sphinx-copybutton", "sphinx-inline
 tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
 
 [[package]]
+name = "pluggy"
+version = "1.3.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
+    {file = "pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "protobuf"
 version = "4.24.4"
 description = ""
@@ -1875,6 +1968,28 @@ files = [
 
 [package.extras]
 diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pytest"
+version = "7.4.3"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
+    {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -2298,6 +2413,17 @@ files = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+
+[[package]]
 name = "tenacity"
 version = "8.2.3"
 description = "Retry code until it succeeds"
@@ -2578,4 +2704,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "3199fcaa75b8d881e55f9646ac6e74693f161e8605077093bacc4a5ac7bf397f"
+content-hash = "fe55079c7a9ab85f95f746971a9d867f8cf7d37e33eff473d836d91a03cae668"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ packages = [{ include = "crvusdsim" }]
 [tool.poetry.dependencies]
 python = "^3.10"
 curvesim = { git = "https://github.com/curveresearch/curvesim.git" }
+pytest = "^7.4.3"
+hypothesis = "^6.90.0"
 
 
 [build-system]


### PR DESCRIPTION
Summary of changes:

- Add sim_interface for stableswap pools (mostly c/p from curvesim `SimCurvePool`).
- Fix decimals when pulling fee for stableswap pools in subgraph network file.
- Add snapshot context management for stableswap pool (inherited from curvesim).
- Update deps and add pytest/hypothesis. I can remove these changes if they affect your existing dev environment.

Happy to address any concerns.

EDIT: all tests passing (except for those which required the data files, which I don't have).