### PR TITLE
Avoid subgraph rate limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ data/*.html
 
 # Sphinx
 /docs/_build
+
+# Notebooks
+notebooks/dev.ipynb

--- a/crvusdsim/network/subgraph.py
+++ b/crvusdsim/network/subgraph.py
@@ -104,6 +104,153 @@ async def symbol_address(symbol, index=0):
     return (amm_address, controller_address, policy_address)
 
 
+async def get_all(template, key, llamma_address, end_ts=None, first=1000):
+    """
+    Function to ensure we get all results from subgraph
+    despite rate limit (which is at most 1000 results). We assume
+    that we want all rows to have the same timestamp.
+    Parameters
+    ----------
+    template : str
+        A GraphQL query.
+    Returns
+    -------
+    list
+        A list of results.
+    """
+    skip = 0
+    res = []
+    ts = None
+    while True:
+        q = Template(template).substitute(
+            llamma_address=llamma_address.lower(),
+            end_ts=end_ts,
+            first=first,
+            skip=skip,
+        )
+
+        r = await convex_crvusd(q)
+
+        try:
+            r = r[key]
+
+            if len(r):
+                # Fix timestamp key
+                if key == "bands":
+                    for i in range(len(r)):
+                        r[i]["timestamp"] = r[i]["snapshot"]["timestamp"]
+                        del r[i]["snapshot"]
+
+                if not ts:
+                    ts = r[0]["timestamp"]
+
+                r = [item for item in r if item["timestamp"] == ts]
+                res.extend(r)
+
+                if len(r) < first:
+                    break
+
+                skip += first
+
+        except IndexError as e:
+            raise SubgraphResultError(
+                f"No user snapshot for this pool: {llamma_address}"
+            ) from e
+
+    assert len(set([item["timestamp"] for item in res])) == 1
+
+    return res
+
+
+async def get_band_snapshots(llamma_address, end_ts=None, first=1000):
+    """Get all band snapshots for a given pool."""
+    if not end_ts:
+        end_date = datetime.now(timezone.utc)
+        end_ts = int(end_date.timestamp())
+
+    # Using timestamp_gte in query because we can't sort by timestamp :(
+    end_ts -= 86400
+
+    # pylint: disable=consider-using-f-string
+    template_query = """
+        query bandSnapshot {
+            bands(
+                first: $first,
+                skip: $skip,
+                where: {
+                    snapshot_: {
+                        llamma: "$llamma_address"
+                        timestamp_gte: $end_ts
+                    }
+                }
+            ) {
+                id
+                index
+                stableCoin
+                collateral
+                collateralUsd
+                priceOracleUp
+                priceOracleDown
+                snapshot {
+                    timestamp
+                }
+            }
+        }
+    """
+
+    res = await get_all(
+        template_query, "bands", llamma_address, end_ts=end_ts, first=first
+    )
+    return res
+
+
+async def get_user_snapshots(llamma_address, end_ts=None, first=1000):
+    """Get all user state snapshots for a given pool."""
+    if not end_ts:
+        end_date = datetime.now(timezone.utc)
+        end_ts = int(end_date.timestamp())
+
+    # pylint: disable=consider-using-f-string
+    template_query = """
+        query UserSnapshots {
+            userStateSnapshots(
+                orderBy: timestamp,
+                orderDirection: desc,
+                first: $first,
+                skip: $skip,
+                where: {
+                    market_: {
+                        amm: "$llamma_address"
+                    }
+                    timestamp_lte: $end_ts
+                }
+            ) {
+                id
+                user {
+                    id
+                }
+                collateral
+                depositedCollateral
+                collateralUp
+                loss
+                lossPct
+                stablecoin
+                n
+                n1
+                n2
+                debt
+                health
+                timestamp
+            }
+        }
+    """
+
+    res = await get_all(
+        template_query, "userStateSnapshots", llamma_address, end_ts=end_ts, first=first
+    )
+    return res
+
+
 async def get_debt_ceiling(address):
     """
     Async function to get debt ceiling
@@ -167,8 +314,8 @@ async def _market_snapshot(
                 where: {
                     llamma: "$llamma_address"
                     timestamp_lte: $end_ts
-                    bandSnapshot: $use_band_snapshot
-                    userStateSnapshot: $use_user_snapshot
+                    bandSnapshot: false
+                    userStateSnapshot: false
                 }
             ) {
                 id
@@ -308,28 +455,25 @@ async def _market_snapshot(
     q = Template(template_query).substitute(
         llamma_address=llamma_address.lower(),
         end_ts=end_ts,
-        use_band_snapshot="true" if use_band_snapshot else "false",
-        use_user_snapshot="false",
     )
 
     r = await convex_crvusd(q)
-
-    if use_user_snapshot:
-        q2 = Template(template_query).substitute(
-            llamma_address=llamma_address.lower(),
-            end_ts=end_ts,
-            use_band_snapshot="false",
-            use_user_snapshot="true",
-        )
-        r2 = await convex_crvusd(q2)
 
     try:
         res = r["snapshots"][0]
         res["llammaRate"] = r["llammaRates"][0]
 
         if use_user_snapshot:
+            user_data = await get_user_snapshots(llamma_address, end_ts=end_ts)
+            logger.debug("User snapshot: %s", user_data)
             res["userStateSnapshot"] = True
-            res["userStates"] = r2["snapshots"][0]["userStates"]
+            res["userStates"] = user_data
+
+        if use_band_snapshot:
+            band_data = await get_band_snapshots(llamma_address, end_ts=end_ts)
+            logger.debug("Bands snapshot: %s", band_data)
+            res["bandSnapshot"] = True
+            res["bands"] = band_data
 
     except IndexError as e:
         raise SubgraphResultError(


### PR DESCRIPTION
### Summary of Changes

1. The subgraph rate limits results to 1000 calls per subquery. This means we were only pulling data on the first 1000 bands (there are always 1024) and the first 1000 users (there could be infinite users). This PR breaks the subquery out into separate queries and ensures we obtain data on all bands and user states using the new `get_all` method.

2. The UserStatesSnapshot, BandsSnapshot, and MarketSnapshot are all taken at different times (several hours apart). This creates a mismatch between the bands data, oracle price, user balances, etc.. This causes some functions to break: loans created after the bands snapshot might seem like they have >0 debt, but 0 collateral. To avoid this error, I am removing loans which have ticks==[] and logging with a warning.

I may open an issue regarding 2(b). I think I can later add a unit test for crvusdsim.pool.get_sim_market to check that the user states pulled from the subgraph (including health) match the user states created in the Controller object. However, I think this can only be fixed by ensuring that the three Snapshots are taken at the same time. Please correct me if I'm wrong here.

### Tests

Passing, except for those which require the data files.