### PR TITLE
Add custom spool snapshot context and metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ data/*.html
 
 # Sphinx
 /docs/_build
+
+# Notebooks
+notebooks/dev.ipynb

--- a/crvusdsim/network/subgraph.py
+++ b/crvusdsim/network/subgraph.py
@@ -339,10 +339,10 @@ async def _market_snapshot(
     return res
 
 
-async def _stableswap_snapshot(pool_addresses):
+async def _stableswap_snapshot(pool_addresses, chain = "mainnet"):
     pools_params = []
     for addr in pool_addresses:
-        r = await _pool_snapshot(address=addr, chain="mainnet", env="prod")
+        r = await _pool_snapshot(address=addr, chain=chain, env="prod")
         coins = []
         for i in range(len(r["pool"]["coins"])):
             coins.append(
@@ -369,6 +369,7 @@ async def _stableswap_snapshot(pool_addresses):
                 "symbol": r["pool"]["symbol"],
                 "decimals": 18,
                 "coins": coins,
+                "chain": chain,
             }
         )
     return pools_params

--- a/crvusdsim/pool/__init__.py
+++ b/crvusdsim/pool/__init__.py
@@ -12,6 +12,7 @@ from crvusdsim.pool.crvusd.mpolicies.monetary_policy import MonetaryPolicy
 from crvusdsim.pool.crvusd.price_oracle.aggregate_stable_price import (
     AggregateStablePrice,
 )
+from crvusdsim.pool.crvusd.stableswap import CurveStableSwapPool
 from crvusdsim.pool.crvusd.price_oracle.price_oracle import PriceOracle
 from crvusdsim.pool.crvusd.stabilizer.peg_keeper import PegKeeper
 from crvusdsim.pool.crvusd.stablecoin import StableCoin
@@ -20,7 +21,7 @@ from crvusdsim.pool.sim_interface.sim_controller import SimController
 from crvusdsim.pool.sim_interface.sim_llamma import SimLLAMMAPool
 from crvusdsim.pool_data import get_metadata
 from curvesim.pool_data.metadata import PoolMetaDataInterface
-from crvusdsim.pool_data.metadata.market import MarketMetaData
+from crvusdsim.pool_data.metadata import MarketMetaData, CurveStableSwapPoolMetaData
 from curvesim.logging import get_logger
 
 __all__ = [
@@ -149,7 +150,14 @@ def get_sim_market(
         pool_kwargs["coins"] = [
             StableCoin(**coin_kwargs) for coin_kwargs in pool_kwargs["coins"]
         ]
-        spool = SimCurveStableSwapPool(**pool_kwargs)
+
+        spool_metadata = CurveStableSwapPoolMetaData(
+            pool_kwargs, CurveStableSwapPool, SimCurveStableSwapPool
+        )
+        spool_init_kwargs = spool_metadata.init_kwargs()
+        spool = SimCurveStableSwapPool(**spool_init_kwargs)
+        spool.metadata = spool_metadata._dict  # pylint: disable=protected-access
+
         spool.coins[1] = stablecoin
 
         # mint token to pool

--- a/crvusdsim/pool/crvusd/stableswap.py
+++ b/crvusdsim/pool/crvusd/stableswap.py
@@ -8,12 +8,14 @@ from collections import defaultdict
 from typing import List, Tuple, Type
 
 from curvesim.pool.base import Pool
-from curvesim.pool.snapshot import CurvePoolBalanceSnapshot, Snapshot
+from curvesim.pool.snapshot import Snapshot
 from curvesim.pool.stableswap.pool import CurvePool
 from crvusdsim.pool.crvusd.stablecoin import StableCoin
 from crvusdsim.pool.crvusd.clac import exp, shift
 from crvusdsim.pool.crvusd.utils import BlocktimestampMixins
 from crvusdsim.pool.crvusd.conf import ARBITRAGUR_ADDRESS
+from crvusdsim.pool.snapshot import CurveStableSwapPoolSnapshot
+from curvesim.utils import override
 
 PRECISION = 10**18
 A_PRECISION = 100
@@ -25,7 +27,7 @@ LP_PROVIDER = "LP_PROVIDER"
 
 class CurveStableSwapPool(Pool, BlocktimestampMixins):
 
-    snapshot_class: Type[Snapshot] = CurvePoolBalanceSnapshot
+    snapshot_class: Type[Snapshot] = CurveStableSwapPoolSnapshot
 
     __slots__ = (
         "address",
@@ -142,11 +144,31 @@ class CurveStableSwapPool(Pool, BlocktimestampMixins):
             if self.balances[i] > 0:
                 self.coins[i]._mint(self.address, self.balances[i])
 
+    @property
+    @override
+    def coin_names(self):
+        return [c.name for c in self.coins]
+
+    @property
+    @override
+    def coin_addresses(self):
+        return [c.address for c in self.coins]
+
+    @property
+    @override
+    def coin_decimals(self):
+        return [c.decimals for c in self.coins]
+
     def _xp_mem(self, _rates: List[int], _balances: List[int]) -> List[int]:
         result: List[int] = [0] * self.n
         for i in range(self.n):
             result[i] = _rates[i] * _balances[i] // PRECISION
         return result
+
+    def _xp(self) -> List[int]:
+        rates = self.rates
+        balances = self.balances
+        return self._xp_mem(rates, balances)
 
     def get_D(self, _xp: List[int], _amp: int) -> int:
         """

--- a/crvusdsim/pool/sim_interface/__init__.py
+++ b/crvusdsim/pool/sim_interface/__init__.py
@@ -2,3 +2,4 @@ __all__ = ["SimLLAMMAPool"]
 
 from .sim_llamma import SimLLAMMAPool
 from .sim_controller import SimController
+from .sim_stableswap import SimCurveStableSwapPool

--- a/crvusdsim/pool/sim_interface/sim_stableswap.py
+++ b/crvusdsim/pool/sim_interface/sim_stableswap.py
@@ -5,7 +5,7 @@ from curvesim.utils import cache, override
 from curvesim.pool.sim_interface.asset_indices import AssetIndicesMixin
 from crvusdsim.pool.crvusd.conf import ARBITRAGUR_ADDRESS
 
-from ..crvusd.stableswap import CurveStableSwapPool
+from ..crvusd.stableswap import CurveStableSwapPool, PRECISION
 
 
 class SimCurveStableSwapPool(SimPool, AssetIndicesMixin, CurveStableSwapPool):
@@ -88,10 +88,11 @@ class SimCurveStableSwapPool(SimPool, AssetIndicesMixin, CurveStableSwapPool):
             (amount of coin `j` received, trading fee)
         """
         if size == 0:
-            return 0, 0
+            return 0
         self.coins[i]._mint(user, size)
         amount_out = self.exchange(i, j, size)
         return amount_out
+
     @override
     def get_max_trade_size(self, i, j, out_balance_perc=0.01):
         """
@@ -116,8 +117,8 @@ class SimCurveStableSwapPool(SimPool, AssetIndicesMixin, CurveStableSwapPool):
         xp = self._xp()
         xp_j = int(xp[j] * out_balance_perc)
 
-        in_amount = self.get_y(j, i, xp_j, xp) - xp[i]
-        return in_amount
+        in_amount = self.get_y(j, i, xp_j, xp, 0, 0) - xp[i]
+        return in_amount * PRECISION // self.rates[i]
 
     @override
     def get_min_trade_size(self, i):

--- a/crvusdsim/pool/snapshot.py
+++ b/crvusdsim/pool/snapshot.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from curvesim.pool.snapshot import Snapshot
 
 class Loan:
@@ -209,3 +210,24 @@ class ControllerSnapshot(Snapshot):
 
         controller.liquidation_discount = self.liquidation_discount
         controller.loan_discount = self.loan_discount
+
+
+class CurveStableSwapPoolSnapshot(Snapshot):
+    """Snapshot that saves pool balances and admin balances."""
+
+    def __init__(self, balances, admin_balances, coins):
+        self.balances = balances
+        self.admin_balances = admin_balances
+        self.coins = coins
+
+    @classmethod
+    def create(cls, pool):
+        balances = pool.balances.copy()
+        admin_balances = pool.admin_balances.copy()
+        coins = [deepcopy(c) for c in pool.coins]
+        return cls(balances, admin_balances, coins)
+
+    def restore(self, pool):
+        pool.balances = self.balances.copy()
+        pool.admin_balances = self.admin_balances.copy()
+        pool.coins = [deepcopy(c) for c in self.coins]

--- a/crvusdsim/pool_data/metadata/__init__.py
+++ b/crvusdsim/pool_data/metadata/__init__.py
@@ -4,9 +4,11 @@ __all__ = [
     "OneUserBandsStrategy",
     "IinitYBandsStrategy",
     "UserLoansBandsStrategy",
+    "CurveStableSwapPoolMetaData",
 ]
 
 from .market import MarketMetaData
+from .stableswap import CurveStableSwapPoolMetaData
 from .bands_strategy import (
     BandsStrategy,
     OneUserBandsStrategy,

--- a/crvusdsim/pool_data/metadata/stableswap.py
+++ b/crvusdsim/pool_data/metadata/stableswap.py
@@ -1,0 +1,44 @@
+from curvesim.pool_data.metadata.base import PoolMetaDataBase
+
+
+class CurveStableSwapPoolMetaData(PoolMetaDataBase):
+    """Specific implementation of the `PoolMetaDataInterface` for Stableswap."""
+
+    def init_kwargs(self):
+        data = self._dict
+
+        def process_to_kwargs(data):
+            kwargs = {
+                "A": data["A"],
+                "D": data["D"],
+                "n": data["n"],
+                "rates": data["rates"],
+                "fee": data["fee"],
+                "admin_fee": data["admin_fee"],
+                "address": data["address"],
+                "decimals": data["decimals"],
+                "name": data["name"],
+                "symbol": data["symbol"],
+                "coins": data["coins"],
+            }
+            return kwargs
+
+        kwargs = process_to_kwargs(data)
+
+        return kwargs
+
+    @property
+    def coins(self):
+        return self._dict["coins"]
+
+    @property
+    def coin_names(self):
+        return [c.name for c in self._dict["coins"]]
+
+    @property
+    def coin_addresses(self):
+        return [c.address for c in self._dict["coins"]]
+
+    @property
+    def n(self):
+        return self._dict["n"]


### PR DESCRIPTION
### Summary of Changes

1. Create custom `MetaData` object for `SimCurveStableSwapPool`. This makes the data-fetching for crvusd's stableswap pools consistent with the data-fetching for curve pools on `curvesim`. The `MetaData` object implements an `init_kwargs` for creating `SimCurveStableSwapPool`s. We then add the metadata to the `.metadata` attribute of the `SimCurveStableSwapPool` to make it compatible with other methods inherited from `curvesim`.
2. Create a custom `Snapshot` object for `SimCurveStableSwapPool`. This allows us to use `use_snapshot_context` and ensure that any `transfer`s or `_mint`s are reverted post-snapshot. **NOTE:** I believe something similar should be done for the Snapshot context for `SimController` and `SimLLAMMA`.
3. Perform some minor bug fixes.

### Tests

Passing, except for those which require the data files.