### PR TITLE
Set PK and Controller debt ceilings and Stablecoin balances

### DIFF
--- a/crvusdsim/network/subgraph.py
+++ b/crvusdsim/network/subgraph.py
@@ -581,6 +581,13 @@ async def market_snapshot(
         [p["pool"] for p in peg_keepers_params]
     )
 
+    # debt ceilings for controller and pks
+    debt_ceilings = {}
+    for address in [r["market"]["controller"]] + [
+        p["address"] for p in peg_keepers_params
+    ]:
+        debt_ceilings[address] = await get_debt_ceiling(address)
+
     # Output
     data = {
         "llamma_params": {
@@ -653,6 +660,7 @@ async def market_snapshot(
         "timestamp": r["timestamp"],
         "index": r["market"]["index"],
         "coins": coins,
+        "debt_ceilings": debt_ceilings
     }
 
     return data

--- a/crvusdsim/network/subgraph.py
+++ b/crvusdsim/network/subgraph.py
@@ -265,6 +265,8 @@ async def get_debt_ceiling(address):
     int
 
     """
+    address = address.lower()
+
     # pylint: disable=consider-using-f-string
     q = """
         query GetDebtCeiling {
@@ -292,7 +294,7 @@ async def get_debt_ceiling(address):
     if len(data["debtCeilings"]) < 1:
         raise SubgraphResultError("No debt ceiling found for symbol query.")
 
-    ceiling = int(data["debtCeilings"][0])
+    ceiling = int(data["debtCeilings"][0]["debtCeiling"])
 
     return ceiling
 
@@ -658,3 +660,4 @@ async def market_snapshot(
 
 symbol_address_sync = sync(symbol_address)
 market_snapshot_sync = sync(market_snapshot)
+debt_ceiling_sync = sync(get_debt_ceiling)

--- a/crvusdsim/pool/__init__.py
+++ b/crvusdsim/pool/__init__.py
@@ -22,7 +22,6 @@ from crvusdsim.pool.sim_interface.sim_stableswap import SimCurveStableSwapPool
 from crvusdsim.pool.sim_interface.sim_controller import SimController
 from crvusdsim.pool.sim_interface.sim_llamma import SimLLAMMAPool
 from crvusdsim.pool_data import get_metadata
-from crvusdsim.network.subgraph import debt_ceiling_sync
 from curvesim.pool_data.metadata import PoolMetaDataInterface
 from crvusdsim.pool_data.metadata import MarketMetaData, CurveStableSwapPoolMetaData
 from curvesim.logging import get_logger
@@ -276,7 +275,7 @@ def get_sim_market(
             _address=peg_keepers_kwargs[i]["address"],
             debt=int(peg_keepers_kwargs[i]["debt"]),
         )
-        pk_debt_ceiling = debt_ceiling_sync(pk.address)
+        pk_debt_ceiling = pool_metadata._dict["debt_ceilings"][pk.address]
         factory.set_debt_ceiling(pk.address, pk_debt_ceiling)
         stablecoin.burnFrom(pk.address, pk.debt)
         peg_keepers.append(pk)
@@ -299,7 +298,7 @@ def get_sim_market(
     )
 
     # add_market in factory
-    controller_debt_ceiling = debt_ceiling_sync(controller.address)
+    controller_debt_ceiling = pool_metadata._dict["debt_ceilings"][controller.address]
     factory._add_market_without_creating(
         pool, controller, policy, collateral_token, controller_debt_ceiling
     )

--- a/crvusdsim/pool/__init__.py
+++ b/crvusdsim/pool/__init__.py
@@ -22,6 +22,7 @@ from crvusdsim.pool.sim_interface.sim_stableswap import SimCurveStableSwapPool
 from crvusdsim.pool.sim_interface.sim_controller import SimController
 from crvusdsim.pool.sim_interface.sim_llamma import SimLLAMMAPool
 from crvusdsim.pool_data import get_metadata
+from crvusdsim.network.subgraph import debt_ceiling_sync
 from curvesim.pool_data.metadata import PoolMetaDataInterface
 from crvusdsim.pool_data.metadata import MarketMetaData, CurveStableSwapPoolMetaData
 from curvesim.logging import get_logger
@@ -264,8 +265,9 @@ def get_sim_market(
 
         aggregator.add_price_pair(spool)
 
-    peg_keepers = [
-        PegKeeper(
+    peg_keepers = []
+    for i in range(len(peg_keepers_kwargs)):
+        pk = PegKeeper(
             _pool=stableswap_pools[i],
             _index=int(PEG_KEEPER_CONF["index"]),
             _caller_share=int(PEG_KEEPER_CONF["caller_share"]),
@@ -274,8 +276,11 @@ def get_sim_market(
             _address=peg_keepers_kwargs[i]["address"],
             debt=int(peg_keepers_kwargs[i]["debt"]),
         )
-        for i in range(len(peg_keepers_kwargs))
-    ]
+        pk_debt_ceiling = debt_ceiling_sync(pk.address)
+        factory.set_debt_ceiling(pk.address, pk_debt_ceiling)
+        stablecoin.burnFrom(pk.address, pk.debt)
+        peg_keepers.append(pk)
+
     policy = MonetaryPolicy(
         price_oracle_contract=aggregator,
         controller_factory_contract=factory,
@@ -294,9 +299,12 @@ def get_sim_market(
     )
 
     # add_market in factory
+    controller_debt_ceiling = debt_ceiling_sync(controller.address)
     factory._add_market_without_creating(
-        pool, controller, policy, collateral_token, MARKET_DEBT_CEILING
+        pool, controller, policy, collateral_token, controller_debt_ceiling
     )
+    controller_debt = sum([loan.initial_debt for loan in controller.loan.values()])
+    stablecoin.burnFrom(controller.address, controller_debt)
 
     pool.metadata = pool_metadata._dict  # pylint: disable=protected-access
     pool.metadata["address"] = pool_metadata._dict["llamma_params"]["address"]

--- a/crvusdsim/pool/crvusd/stabilizer/peg_keeper.py
+++ b/crvusdsim/pool/crvusd/stabilizer/peg_keeper.py
@@ -209,8 +209,8 @@ class PegKeeper(BlocktimestampMixins):
         if self.last_change + ACTION_DELAY > self._block_timestamp:
             return 0
 
-        balance_pegged: int = self.POOL.balances(self.I)
-        balance_peg: int = self.POOL.balances(1 - self.I) * self.PEG_MUL
+        balance_pegged: int = self.POOL.balances[self.I]
+        balance_peg: int = self.POOL.balances[1 - self.I] * self.PEG_MUL
 
         initial_profit: int = self._calc_profit()
 


### PR DESCRIPTION
### Summary of Changes

1. Fix minor bug in `crvusdsim/network/subgraph.py` to fetch debt ceilings from subgraph.
2. Use `debt_ceiling_sync` to load `PegKeeper`s and `Controller` with the actual debt ceiling. 
a. The `Controller`'s debt ceiling was hard coded at 10M
b. The `PegKeeper` didn't have a set debt ceiling, which prevented the `update` function from being called.
3. Correct the stablecoin `balanceOf` for the `PegKeeper` and `Controller` to ensure their balances reflect `debt_ceiling - debt`. For example, if the `Controller` has a debt ceiling of 200M but has 20M of outstanding debt, then its `balanceOf` should be 180M.

### Tests

Passing.

NOTE: The debt ceiling query results are new keys in the `pool_metadata` dict. To run the tests with local metadata files, they need to be updated to include the `debt_ceilings` item. The one I am using is attached below:

[pool_metadata_0x37417B2238AA52D0DD2D6252d989E728e8f706e4.json](https://github.com/0xreviews/crvusdsim/files/13562873/pool_metadata_0x37417B2238AA52D0DD2D6252d989E728e8f706e4.json)
