### PR TITLE
Bug Fixes

### DIFF
--- a/crvusdsim/network/subgraph.py
+++ b/crvusdsim/network/subgraph.py
@@ -588,6 +588,9 @@ async def market_snapshot(
     ]:
         debt_ceilings[address] = await get_debt_ceiling(address)
 
+    # fix base price
+    r["basePrice"] = str(float(r["basePrice"]) / float(r["llammaRate"]["rateMul"]) * 1e18)
+
     # Output
     data = {
         "llamma_params": {

--- a/crvusdsim/pool/crvusd/controller.py
+++ b/crvusdsim/pool/crvusd/controller.py
@@ -150,7 +150,7 @@ class Controller(
         self.liquidation_discounts = (
             liquidation_discounts
             if liquidation_discounts is not None
-            else defaultdict(int)
+            else defaultdict(lambda: liquidation_discount)
         )
 
         self._total_debt = total_debt if total_debt is not None else Loan()

--- a/crvusdsim/pool/crvusd/controller.py
+++ b/crvusdsim/pool/crvusd/controller.py
@@ -2,6 +2,7 @@
 Mainly a module to house the `Curve Stablecoin`, a Controller implementation in Python.
 """
 from collections import defaultdict
+from functools import partial
 from typing import Callable, List, Tuple
 from math import floor, sqrt, isqrt, log as math_log
 
@@ -150,7 +151,7 @@ class Controller(
         self.liquidation_discounts = (
             liquidation_discounts
             if liquidation_discounts is not None
-            else defaultdict(lambda: liquidation_discount)
+            else defaultdict(partial(type(liquidation_discount), liquidation_discount))
         )
 
         self._total_debt = total_debt if total_debt is not None else Loan()

--- a/crvusdsim/pool_data/metadata/market.py
+++ b/crvusdsim/pool_data/metadata/market.py
@@ -76,9 +76,15 @@ class MarketMetaData(PoolMetaDataBase):
             bands_y = defaultdict(int)
 
             for b in data["llamma_params"]["bands_x"]:
-                bands_x[int(b)] = int(data["llamma_params"]["bands_x"][b])
-            for b in data["llamma_params"]["bands_y"]:
-                bands_y[int(b)] = int(data["llamma_params"]["bands_y"][b])
+                b = int(b)
+                b_x = int(data["llamma_params"]["bands_x"][b])
+                b_y = int(data["llamma_params"]["bands_y"][b])
+                bands_x[b] = b_x
+                bands_y[b] = b_y
+                # override active_band since bands data is 
+                # snapshot at a different time
+                if b_x > 0 and b_y > 0:
+                    pool_kwargs["active_band"] = b  
 
             pool_kwargs["bands_x"] = bands_x
             pool_kwargs["bands_y"] = bands_y

--- a/crvusdsim/pool_data/metadata/market.py
+++ b/crvusdsim/pool_data/metadata/market.py
@@ -126,12 +126,10 @@ class MarketMetaData(PoolMetaDataBase):
                     if broken_user:
                         continue
 
-                    # As in Vyper code, user shares reflect their deposited
-                    # collateral in a band.
                     for b_i in range(n1, n2 + 1):
-                        deposited_collateral = format_float_to_uint256(_u["depositedCollateral"]) // N
-                        total_shares[b_i] += deposited_collateral
-                        ticks.append(deposited_collateral)
+                        collateral_up = format_float_to_uint256(_u["collateralUp"]) // N
+                        total_shares[b_i] += collateral_up
+                        ticks.append(collateral_up)
 
                     user_shares[user_address] = UserShares(n1,n2,ticks)
 


### PR DESCRIPTION
### Summary of Changes

1.  The `basePrice` from the subgraph is not `BASE_PRICE`, it's `BASE_PRICE * rateMul`. Therefore, to get the actual `BASE_PRICE`, we need to divide by `rateMul` first. This bug impacted primarily the `p_oracle_up` and `p_oracle_down` for LLAMMA, causing the Controller to meaningfully over-estimate the health of some borrowers.
2. Change the default for `liquidation_discounts` array to the `liquidation_discount` instead of `0`. This will apply to positions initialized from the subgraph (shouldn't impact those initialized by bands strategies).
3. Change the way we initialize user shares from the subgraph to use the `collateralUp` field instead of the `collateral` field. This is more accurate (captures losses from soft liquidations).
4. The `active_band` was being initialized from the `MarketSnapshot`. This is different from the `active_band` we get from the `bands` Snapshot, because they are taken at different times. In days of higher volatility, we were incorrectly loading in an `active_band` from the `MarketSnapshot` (e.g. `-18`), whereas the `active_band` according to the actual `bands` data could be (e.g.) `-20`. This would cause `LLAMMA` to incorrectly calculate each user's `collateral` and `stablecoin` amounts!

### Tests

Passing.