### PR TITLE
Add High Fidelity Oracle with TriCrypto

### DIFF
--- a/crvusdsim/network/subgraph.py
+++ b/crvusdsim/network/subgraph.py
@@ -588,6 +588,9 @@ async def market_snapshot(
     ]:
         debt_ceilings[address] = await get_debt_ceiling(address)
 
+    # fix base price
+    r["basePrice"] = str(float(r["basePrice"]) / float(r["llammaRate"]["rateMul"]) * 1e18)
+
     # Output
     data = {
         "llamma_params": {

--- a/crvusdsim/pool/__init__.py
+++ b/crvusdsim/pool/__init__.py
@@ -57,7 +57,7 @@ class SimMarketInstance:
         peg_keepers: List[PegKeeper],
         policy: MonetaryPolicy,
         factory: ControllerFactory,
-        tricrypto: SimCurveCryptoPool | None = None
+        tricrypto: List[SimCurveCryptoPool] = [],
     ):
         self.pool = pool
         self.controller = controller
@@ -332,7 +332,7 @@ def get_sim_market(
         peg_keepers,
         policy,
         factory,
-        None,  # tricrypto
+        [],  # tricrypto
     )
 
     if not use_simple_oracle:

--- a/crvusdsim/pool/__init__.py
+++ b/crvusdsim/pool/__init__.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from typing import List
 from curvesim.exceptions import CurvesimValueError
+from curvesim.pool.sim_interface import SimCurveCryptoPool
 from crvusdsim.pool.crvusd.LLAMMA import LLAMMAPool
 from crvusdsim.pool.crvusd.conf import (
     AGGREGATOR_CONF,
@@ -15,6 +16,10 @@ from crvusdsim.pool.crvusd.price_oracle.aggregate_stable_price import (
 )
 from crvusdsim.pool.crvusd.stableswap import CurveStableSwapPool
 from crvusdsim.pool.crvusd.price_oracle.price_oracle import PriceOracle
+from crvusdsim.pool.crvusd.price_oracle.crypto_with_stable_price import (
+    Oracle,
+    get_oracle,
+)
 from crvusdsim.pool.crvusd.stabilizer.peg_keeper import PegKeeper
 from crvusdsim.pool.crvusd.stablecoin import StableCoin
 from crvusdsim.pool.crvusd.utils.ERC20 import ERC20
@@ -47,11 +52,12 @@ class SimMarketInstance:
         collateral_token: ERC20,
         stablecoin: StableCoin,
         aggregator: AggregateStablePrice,
-        price_oracle: PriceOracle,
+        price_oracle: PriceOracle | Oracle,
         stableswap_pools: List[SimCurveStableSwapPool],
         peg_keepers: List[PegKeeper],
         policy: MonetaryPolicy,
         factory: ControllerFactory,
+        tricrypto: SimCurveCryptoPool | None = None
     ):
         self.pool = pool
         self.controller = controller
@@ -63,6 +69,7 @@ class SimMarketInstance:
         self.peg_keepers = peg_keepers
         self.policy = policy
         self.factory = factory
+        self.tricrypto = tricrypto
 
     def __iter__(self):
         return iter((
@@ -143,6 +150,7 @@ def get_sim_market(
     end_ts=None,
     src=None,
     data_dir=None,
+    use_simple_oracle=True,
 ):
     """
     Factory function for creating related entities (e.g. SimLLAMMAPool, SimController)
@@ -166,6 +174,10 @@ def get_sim_market(
     end_ts: int, optional
         Posix timestamp indicating the datetime of the metadata snapshot.
         Only used when `pool_metadata` is an address.
+
+    use_simple_oracle: bool, default=True
+        If True, use the simple oracle. Otherwise, use an oracle specific to the given
+        market and fetch necessary TriCrypto-ng pools.
 
     Returns
     -------
@@ -309,7 +321,7 @@ def get_sim_market(
     pool.metadata["address"] = pool_metadata._dict["llamma_params"]["address"]
     pool.metadata["chain"] = "mainnet"
 
-    return SimMarketInstance(
+    sim_market = SimMarketInstance(
         pool,
         controller,
         collateral_token,
@@ -320,7 +332,25 @@ def get_sim_market(
         peg_keepers,
         policy,
         factory,
+        None,  # tricrypto
     )
+
+    if not use_simple_oracle:
+        # Override simple oracle
+        oracle = get_oracle(
+            sim_market.pool.address, 
+            sim_market.factory, 
+            sim_market.aggregator, 
+            sim_market.stableswap_pools, 
+            end_ts=end_ts
+        )
+        tricrypto = oracle.tricrypto
+        # rebind
+        sim_market.tricrypto = tricrypto
+        sim_market.price_oracle = oracle
+        sim_market.pool.price_oracle_contract = oracle
+    
+    return sim_market
 
 
 get = get_sim_market

--- a/crvusdsim/pool/crvusd/conf/__init__.py
+++ b/crvusdsim/pool/crvusd/conf/__init__.py
@@ -58,6 +58,12 @@ AGGREGATOR_CONF = {
 
 ARBITRAGUR_ADDRESS = "ARBITRAGUR"
 
+LLAMMA_WETH = "0x1681195c176239ac5e72d9aebacf5b2492e0c4ee"
+LLAMMA_WBTC = "0xe0438eb3703bf871e31ce639bd351109c88666ea"
+LLAMMA_SFRXETH = "0xfa96ad0a9e64261db86950e2da362f5572c5c6fd"
+LLAMMA_WSTETH = "0x37417b2238aa52d0dd2d6252d989e728e8f706e4"
+LLAMMA_TBTC = "0xf9bd9da2427a50908c4c6d1599d8e62837c2bcb0"
+
 ALIAS_TO_ADDRESS = {
     "crvUSD": "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",
     "wstETH": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
@@ -66,10 +72,10 @@ ALIAS_TO_ADDRESS = {
     "TUSD": "0x0000000000085d4780B73119b644AE5ecd22b376",
     "USDP": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
     "llamma_sfrxeth_v1": "0x136e783846ef68c8bd00a3369f787df8d683a696",
-    "llamma_sfrxeth": "0xfa96ad0a9e64261db86950e2da362f5572c5c6fd",
-    "llamma_sfrxeth_v2": "0xfa96ad0a9e64261db86950e2da362f5572c5c6fd",
-    "llamma_wsteth": "0x37417b2238aa52d0dd2d6252d989e728e8f706e4",
-    "llamma_weth": "0x1681195c176239ac5e72d9aebacf5b2492e0c4ee",
-    "llamma_wbtc": "0xe0438eb3703bf871e31ce639bd351109c88666ea",
-    "llamma_tbtc": "0xf9bd9da2427a50908c4c6d1599d8e62837c2bcb0",
+    "llamma_sfrxeth": LLAMMA_SFRXETH,
+    "llamma_sfrxeth_v2": LLAMMA_SFRXETH,
+    "llamma_wsteth": LLAMMA_WSTETH,
+    "llamma_weth": LLAMMA_WETH,
+    "llamma_wbtc": LLAMMA_WBTC,
+    "llamma_tbtc": LLAMMA_TBTC,
 }

--- a/crvusdsim/pool/crvusd/controller.py
+++ b/crvusdsim/pool/crvusd/controller.py
@@ -150,7 +150,7 @@ class Controller(
         self.liquidation_discounts = (
             liquidation_discounts
             if liquidation_discounts is not None
-            else defaultdict(int)
+            else defaultdict(lambda: liquidation_discount)
         )
 
         self._total_debt = total_debt if total_debt is not None else Loan()

--- a/crvusdsim/pool/crvusd/controller.py
+++ b/crvusdsim/pool/crvusd/controller.py
@@ -2,6 +2,7 @@
 Mainly a module to house the `Curve Stablecoin`, a Controller implementation in Python.
 """
 from collections import defaultdict
+from functools import partial
 from typing import Callable, List, Tuple
 from math import floor, sqrt, isqrt, log as math_log
 
@@ -150,7 +151,7 @@ class Controller(
         self.liquidation_discounts = (
             liquidation_discounts
             if liquidation_discounts is not None
-            else defaultdict(lambda: liquidation_discount)
+            else defaultdict(partial(type(liquidation_discount), liquidation_discount))
         )
 
         self._total_debt = total_debt if total_debt is not None else Loan()

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price.py
@@ -1,0 +1,134 @@
+"""
+Provides a price oracle class that uses Tricrypto-ng
+and StableSwap pools to calculate collateral prices.
+
+TODO - add Chainlink price limits.
+"""
+from typing import List
+from curvesim.pool.sim_interface import SimCurveCryptoPool
+from . import AggregateStablePrice
+from .. import ControllerFactory
+from ..stablecoin import StableCoin
+from ..clac import exp
+from ..utils import BlocktimestampMixins, ERC20
+from ...sim_interface import SimCurveStableSwapPool
+
+PRECISION = 10**18
+
+
+class CryptoWithStablePrice(BlocktimestampMixins):
+    def __init__(
+        self,
+        tricrypto: List[SimCurveCryptoPool],
+        ix: List[int],  # 1 = ETH
+        stableswap: List[SimCurveStableSwapPool],
+        stable_aggregator: AggregateStablePrice,
+        factory: ControllerFactory,
+        # chainlink_aggregator_eth: ChainlinkAggregator,
+        # bound_size: int,  # 1.5% sounds ok before we turn it off
+        n_pools=2,
+        tvl_ma_time=50000,
+    ) -> None:
+        super().__init__()
+        self.tricrypto = tricrypto
+        self.tricrypto_ix = ix
+        self.stableswap = stableswap
+        self.stable_aggregator = stable_aggregator
+        self.factory = factory
+        self._stablecoin: StableCoin = stable_aggregator.STABLECOIN
+        self.n_pools = n_pools
+        self.tvl_ma_time = tvl_ma_time
+
+        self._redeemable: List[ERC20] = []  # redeemable stablecoin addrs (e.g. USDC)
+        self._is_inverse: List[bool] = []
+        self.last_tvl: List[int] = []
+        for i in range(n_pools):
+            coins = stableswap[i].coins
+            if coins[0] is self._stablecoin:
+                self._redeemable.append(coins[1])
+                self._is_inverse.append(True)
+            else:
+                self._redeemable.append(coins[0])
+                self._is_inverse.append(False)
+                assert coins[1] is self._stablecoin
+            assert tricrypto[i].coin_addresses[0] == self._redeemable[i].address
+            self.last_tvl[i] = (
+                tricrypto[i].tokens * tricrypto[i].virtual_price // PRECISION
+            )
+
+        self.last_timestamp = self._block_timestamp
+        # self.use_chainlink = False
+        # CHAINLINK_AGGREGATOR_ETH = chainlink_aggregator_eth
+        # CHAINLINK_PRICE_PRECISION_ETH = 10**convert(chainlink_aggregator_eth.decimals(), uint256)
+        # BOUND_SIZE = bound_size
+
+    def _ema_tvl(self) -> List[int]:
+        last_timestamp = self.last_timestamp
+        last_tvl = self.last_tvl
+
+        if last_timestamp < self._block_timestamp:
+            alpha = exp(
+                -1
+                * int(self._block_timestamp - last_timestamp)
+                * PRECISION
+                // self.tvl_ma_time
+            )
+            # alpha = 1.0 when dt = 0
+            # alpha = 0.0 when dt = inf
+            for i in range(self.n_pools):
+                tricrypto = self.tricrypto[i]
+                tvl = tricrypto.tokens * tricrypto.virtual_price() // PRECISION
+                last_tvl[i] = (
+                    tvl * (PRECISION - alpha) + last_tvl[i] * alpha
+                ) // PRECISION
+
+        return last_tvl
+
+    def ema_tvl(self) -> List[int]:
+        return self._ema_tvl()
+
+    def _raw_price(self, tvls: List[int], agg_price: int) -> int:
+        weighted_price = 0
+        weights = 0
+        for i in range(self.n_pools):
+            p_crypto_r = self.tricrypto[i].price_oracle(
+                self.tricrypto_ix[i]
+            )  # d_usdt/d_eth
+            p_stable_r = self.stableswap[i].price_oracle()  # d_usdt/d_st
+            p_stable_agg = agg_price  # d_usd/d_st
+            if self._is_inverse[i]:
+                p_stable_r = 10**36 // p_stable_r
+            weight = tvls[i]
+            # Prices are already EMA but weights - not so much
+            weights += weight
+            weighted_price += (
+                p_crypto_r * p_stable_agg // p_stable_r * weight
+            )  # d_usd/d_eth
+        crv_p = weighted_price // weights
+
+        # Limit BTC price
+        # if self.use_chainlink:
+        #     chainlink_lrd: ChainlinkAnswer = CHAINLINK_AGGREGATOR_ETH.latestRoundData()
+        #     if block.timestamp - min(chainlink_lrd.updated_at, block.timestamp) <= CHAINLINK_STALE_THRESHOLD:
+        #         chainlink_p = convert(chainlink_lrd.answer, uint256) * PRECISION / CHAINLINK_PRICE_PRECISION_ETH
+        #         lower = chainlink_p * (PRECISION - BOUND_SIZE) / PRECISION
+        #         upper = chainlink_p * (PRECISION + BOUND_SIZE) / PRECISION
+        #         crv_p = min(max(crv_p, lower), upper)
+
+        return crv_p
+
+    def raw_price(self) -> int:
+        return self._raw_price(self._ema_tvl(), self.stable_aggregator.price())
+
+    def price(self) -> int:
+        return self._raw_price(self._ema_tvl(), self.stable_aggregator.price())
+
+    def price_w(self) -> int:
+        tvls = self._ema_tvl()
+        if self.last_timestamp < self._block_timestamp:
+            self.last_timestamp = self._block_timestamp
+            self.last_tvl = tvls
+        return self._raw_price(tvls, self.stable_aggregator.price_w())
+
+    def set_use_chainlink(self, do_it: bool) -> None:
+        self.use_chainlink = do_it

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/__init__.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/__init__.py
@@ -13,9 +13,6 @@ Each market has its own implementation:
     and the staking contract.
 3. tBTC: Uses just the crvUSD/tBTC/wstETH TriCrypto-ng pool to provide
     prices.
-
-TODO - add Chainlink price limits.
-TODO - proper documentation here.
 """
 from curvesim.pool import get_sim_pool
 from .base import Oracle

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/__init__.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/__init__.py
@@ -1,0 +1,39 @@
+"""
+Provides all the oracle implementations for
+the crypto with stable price oracle.
+
+Each market has its own implementation:
+1. WBTC & WETH: use the USDC/WBTC/WETH and USDT/WBTC/WETH TriCrypto-ng
+    pools and the USDC/crvUSD and USDT/crvUSD StableSwap pools to 
+    generate prices.
+2. sfrxETH & wstETH: do the same as (1) but with an additional conversion
+    from WETH price to derivative price. We perform this conversion using
+    an input `p_staked` parameter provided by the function caller. This
+    avoids having to explicitly simulate an additional stableswap pool
+    and the staking contract.
+3. tBTC: Uses just the crvUSD/tBTC/wstETH TriCrypto-ng pool to provide
+    prices.
+"""
+"""
+Provides a factory for creating the right
+oracle for a given market.
+"""
+from .base import Oracle
+from .weth import OracleWETH
+from .wbtc import OracleWBTC
+from .sfrxeth import OracleSFRXETH
+from .wsteth import OracleWSTETH
+from .tbtc import OracleTBTC
+
+MAP = {
+    "weth": OracleWETH,
+    "wbtc": OracleWBTC,
+    "sfrxeth": OracleSFRXETH,
+    "wsteth": OracleWSTETH,
+    "tbtc": OracleTBTC,
+}
+
+
+def get_oracle(market: str, *args, **kwargs) -> Oracle:
+    """Return the appropriate Oracle instance."""
+    return MAP[market](*args, **kwargs)

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/__init__.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/__init__.py
@@ -13,27 +13,94 @@ Each market has its own implementation:
     and the staking contract.
 3. tBTC: Uses just the crvUSD/tBTC/wstETH TriCrypto-ng pool to provide
     prices.
+
+TODO - add Chainlink price limits.
+TODO - proper documentation here.
 """
-"""
-Provides a factory for creating the right
-oracle for a given market.
-"""
+from curvesim.pool import get_sim_pool
 from .base import Oracle
 from .weth import OracleWETH
 from .wbtc import OracleWBTC
 from .sfrxeth import OracleSFRXETH
 from .wsteth import OracleWSTETH
 from .tbtc import OracleTBTC
+from ...conf import LLAMMA_TBTC, LLAMMA_WETH, LLAMMA_SFRXETH, LLAMMA_WBTC, LLAMMA_WSTETH
 
 MAP = {
-    "weth": OracleWETH,
-    "wbtc": OracleWBTC,
-    "sfrxeth": OracleSFRXETH,
-    "wsteth": OracleWSTETH,
-    "tbtc": OracleTBTC,
+    LLAMMA_WETH: OracleWETH,
+    LLAMMA_WBTC: OracleWBTC,
+    LLAMMA_SFRXETH: OracleSFRXETH,
+    LLAMMA_WSTETH: OracleWSTETH,
+    LLAMMA_TBTC: OracleTBTC,
 }
 
 
-def get_oracle(market: str, *args, **kwargs) -> Oracle:
+def get_oracle(
+    market: str, factory, aggregator, stableswap_all, end_ts: int | None = None
+) -> Oracle:
     """Return the appropriate Oracle instance."""
-    return MAP[market](*args, **kwargs)
+    tricrypto, stableswap = get_pools(market, stableswap_all, end_ts)
+    kwargs = make_kwargs(market, aggregator, factory, tricrypto, stableswap)
+    return MAP[market.lower()](**kwargs)
+
+
+def get_tricrypto_addresses(market: str) -> list:
+    """Return the TriCrypto pools required for the oracle."""
+    if market.lower() in [LLAMMA_WETH, LLAMMA_WBTC, LLAMMA_SFRXETH, LLAMMA_WSTETH]:
+        return [
+            "0x7f86bf177dd4f3494b841a37e810a34dd56c829b",  # USDC
+            "0xf5f5b97624542d72a9e06f04804bf81baa15e2b4",  # USDT
+        ]
+    elif market.lower() == LLAMMA_TBTC:
+        return ["0x2889302a794dA87fBF1D6Db415C1492194663D13"]
+    else:
+        raise NotImplementedError("Invalid market: %s" % market)
+
+
+def get_stableswap_addresses(market: str) -> list:
+    if market.lower() in [LLAMMA_WETH, LLAMMA_WBTC, LLAMMA_SFRXETH, LLAMMA_WSTETH]:
+        return [
+            "0x4dece678ceceb27446b35c672dc7d61f30bad69e",  # USDC
+            "0x390f3595bca2df7d23783dfd126427cceb997bf4",  # USDT
+        ]
+    elif market.lower() == LLAMMA_TBTC:
+        return []
+    else:
+        raise NotImplementedError("Invalid market: %s" % market)
+
+
+def get_pools(market: str, stableswap_all, end_ts: int | None = None) -> tuple:
+    """Return the pools required to construct the oracle."""
+    tricrypto_addresses = get_tricrypto_addresses(market)
+    tricrypto = [
+        get_sim_pool(a, balanced=False, end_ts=end_ts) for a in tricrypto_addresses
+    ]
+    stableswap = []
+    stableswap_addresses = get_stableswap_addresses(market)
+    for address in stableswap_addresses:
+        for spool in stableswap_all:
+            if spool.address == address:
+                stableswap.append(spool)
+                break
+    return tricrypto, stableswap
+
+
+def make_kwargs(market: str, aggregator, factory, tricrypto, stableswap) -> dict:
+    kwargs = {
+        "tricrypto": tricrypto,
+        "stableswap": stableswap,
+        "stable_aggregator": aggregator,
+        "factory": factory,
+        "n_pools": len(tricrypto),
+        "tvl_ma_time": 50000,
+    }
+    if market in [LLAMMA_WETH, LLAMMA_SFRXETH, LLAMMA_WSTETH]:
+        kwargs["ix"] = [1, 1]
+    elif market == LLAMMA_WBTC:
+        kwargs["ix"] = [0, 0]
+    elif market == LLAMMA_TBTC:
+        kwargs["ix"] = [0]
+    else:
+        raise NotImplementedError("Invalid market: %s" % market)
+
+    return kwargs

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/base.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/base.py
@@ -2,8 +2,6 @@
 Provides the base implementation for the 
 `crypto_with_stable_price` oracles.
 
-Each child class must implement its own price methods.
-
 TODO - add Chainlink price limits.
 """
 from typing import List

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/sfrxeth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/sfrxeth.py
@@ -1,0 +1,90 @@
+"""Provides the sfrxETH price oracle."""
+from typing import List
+from curvesim.pool.sim_interface import SimCurveCryptoPool
+from .base import Oracle
+from ..aggregate_stable_price import AggregateStablePrice
+from ... import ControllerFactory
+from ...utils import BlocktimestampMixins, ERC20
+from ....sim_interface import SimCurveStableSwapPool
+
+PRECISION = 10**18
+
+
+class OracleSFRXETH(Oracle, BlocktimestampMixins):
+    def __init__(
+        self,
+        tricrypto: List[SimCurveCryptoPool],
+        ix: List[int],  # 0 = WBTC
+        stableswap: List[SimCurveStableSwapPool],
+        stable_aggregator: AggregateStablePrice,
+        factory: ControllerFactory,
+        # chainlink_aggregator_eth: ChainlinkAggregator,
+        # bound_size: int,  # 1.5% sounds ok before we turn it off
+        n_pools=2,
+        tvl_ma_time=50000,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            tricrypto,
+            ix,
+            stableswap,
+            stable_aggregator,
+            factory,
+            n_pools,
+            tvl_ma_time,
+            **kwargs,
+        )
+
+    def _raw_price(
+        self, tvls: List[int], agg_price: int, p_staked: int, **kwargs
+    ) -> int:
+        """
+        Get the price of the underlying asset from TriCrypto and StableSwap
+        pools (e.g. ETH price).
+
+        Convert this price to the staked asset price using the given p_staked
+        (e.g. ETH -> sfrxETH).
+        """
+        weighted_price = 0
+        weights = 0
+        for i in range(self.n_pools):
+            p_crypto_r = self.tricrypto[i].price_oracle()[
+                self.tricrypto_ix[i]
+            ]  # d_usdt/d_eth
+            p_stable_r = self.stableswap[i].price_oracle()  # d_usdt/d_crvusd
+            p_stable_agg = agg_price  # d_usd/d_crvusd
+            if self._is_inverse[i]:
+                p_stable_r = 10**36 // p_stable_r
+            weight = tvls[i]
+            weights += weight
+            weighted_price += (
+                p_crypto_r * p_stable_agg // p_stable_r * weight
+            )  # d_usd/d_eth
+        crv_p = weighted_price // weights
+
+        # use_chainlink: bool = self.use_chainlink
+
+        # # Limit ETH price
+        # if use_chainlink:
+        #     chainlink_lrd: ChainlinkAnswer = CHAINLINK_AGGREGATOR_ETH.latestRoundData()
+        #     if block.timestamp - min(chainlink_lrd.updated_at, block.timestamp) <= CHAINLINK_STALE_THRESHOLD:
+        #         chainlink_p = convert(chainlink_lrd.answer) * 10**18 / CHAINLINK_PRICE_PRECISION_ETH
+        #         lower = chainlink_p * (10**18 - BOUND_SIZE) / 10**18
+        #         upper = chainlink_p * (10**18 + BOUND_SIZE) / 10**18
+        #         crv_p = min(max(crv_p, lower), upper)
+
+        return int(p_staked * crv_p // 10**18)
+
+    def raw_price(self, p_staked, **kwargs) -> int:
+        return self._raw_price(
+            self._ema_tvl(), self.stable_aggregator.price(), p_staked, **kwargs
+        )
+
+    def price_w(self, p_staked, **kwargs) -> int:
+        tvls = self._ema_tvl()
+        if self.last_timestamp < self._block_timestamp:
+            self.last_timestamp = self._block_timestamp
+            self.last_tvl = tvls
+        return self._raw_price(
+            tvls, self.stable_aggregator.price_w(), p_staked, **kwargs
+        )

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/sfrxeth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/sfrxeth.py
@@ -1,42 +1,13 @@
 """Provides the sfrxETH price oracle."""
 from typing import List
-from curvesim.pool.sim_interface import SimCurveCryptoPool
 from .base import Oracle
-from ..aggregate_stable_price import AggregateStablePrice
-from ... import ControllerFactory
-from ...utils import BlocktimestampMixins, ERC20
-from ....sim_interface import SimCurveStableSwapPool
 
 PRECISION = 10**18
 
 
-class OracleSFRXETH(Oracle, BlocktimestampMixins):
-    def __init__(
-        self,
-        tricrypto: List[SimCurveCryptoPool],
-        ix: List[int],  # 0 = WBTC
-        stableswap: List[SimCurveStableSwapPool],
-        stable_aggregator: AggregateStablePrice,
-        factory: ControllerFactory,
-        # chainlink_aggregator_eth: ChainlinkAggregator,
-        # bound_size: int,  # 1.5% sounds ok before we turn it off
-        n_pools=2,
-        tvl_ma_time=50000,
-        **kwargs,
-    ) -> None:
-        super().__init__(
-            tricrypto,
-            ix,
-            stableswap,
-            stable_aggregator,
-            factory,
-            n_pools,
-            tvl_ma_time,
-            **kwargs,
-        )
-
+class OracleSFRXETH(Oracle):
     def _raw_price(
-        self, tvls: List[int], agg_price: int, p_staked: int, **kwargs
+        self, tvls: List[int], agg_price: int, p_staked: int = 10**18, **kwargs
     ) -> int:
         """
         Get the price of the underlying asset from TriCrypto and StableSwap
@@ -75,12 +46,12 @@ class OracleSFRXETH(Oracle, BlocktimestampMixins):
 
         return int(p_staked * crv_p // 10**18)
 
-    def raw_price(self, p_staked, **kwargs) -> int:
+    def raw_price(self, p_staked: int = 10**18, **kwargs) -> int:
         return self._raw_price(
             self._ema_tvl(), self.stable_aggregator.price(), p_staked, **kwargs
         )
 
-    def price_w(self, p_staked, **kwargs) -> int:
+    def price_w(self, p_staked: int = 10**18, **kwargs) -> int:
         tvls = self._ema_tvl()
         if self.last_timestamp < self._block_timestamp:
             self.last_timestamp = self._block_timestamp

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/sfrxeth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/sfrxeth.py
@@ -21,7 +21,9 @@ class OracleSFRXETH(Oracle):
         (e.g. ETH -> sfrxETH).
         """
         crv_p = super()._raw_price(tvls, agg_price, *args, **kwargs)
-        return int(self.staked_oracle.price * crv_p // 10**18)
+        crv_p = int(self.staked_oracle.price * crv_p // 10**18)
+        self.last_price = crv_p
+        return crv_p
 
     def update_staked_oracle(self, new: int) -> None:
         """Update the staked oracle price."""

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/sfrxeth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/sfrxeth.py
@@ -1,61 +1,28 @@
 """Provides the sfrxETH price oracle."""
 from typing import List
-from .base import Oracle
+from .base import Oracle, StakedOracle
 
 PRECISION = 10**18
 
 
 class OracleSFRXETH(Oracle):
-    def _raw_price(
-        self, tvls: List[int], agg_price: int, p_staked: int = 10**18, **kwargs
-    ) -> int:
+    """Oracle for sfrxETH"""
+
+    def __init__(self, staked_oracle: StakedOracle | None = None, **kwargs):
+        super().__init__(**kwargs)
+        self.staked_oracle = staked_oracle or StakedOracle()
+
+    def _raw_price(self, tvls: List[int], agg_price: int, *args, **kwargs) -> int:
         """
         Get the price of the underlying asset from TriCrypto and StableSwap
         pools (e.g. ETH price).
 
-        Convert this price to the staked asset price using the given p_staked
+        Convert this price to the staked asset price using staked oracle price.
         (e.g. ETH -> sfrxETH).
         """
-        weighted_price = 0
-        weights = 0
-        for i in range(self.n_pools):
-            p_crypto_r = self.tricrypto[i].price_oracle()[
-                self.tricrypto_ix[i]
-            ]  # d_usdt/d_eth
-            p_stable_r = self.stableswap[i].price_oracle()  # d_usdt/d_crvusd
-            p_stable_agg = agg_price  # d_usd/d_crvusd
-            if self._is_inverse[i]:
-                p_stable_r = 10**36 // p_stable_r
-            weight = tvls[i]
-            weights += weight
-            weighted_price += (
-                p_crypto_r * p_stable_agg // p_stable_r * weight
-            )  # d_usd/d_eth
-        crv_p = weighted_price // weights
+        crv_p = super()._raw_price(tvls, agg_price, *args, **kwargs)
+        return int(self.staked_oracle.price * crv_p // 10**18)
 
-        # use_chainlink: bool = self.use_chainlink
-
-        # # Limit ETH price
-        # if use_chainlink:
-        #     chainlink_lrd: ChainlinkAnswer = CHAINLINK_AGGREGATOR_ETH.latestRoundData()
-        #     if block.timestamp - min(chainlink_lrd.updated_at, block.timestamp) <= CHAINLINK_STALE_THRESHOLD:
-        #         chainlink_p = convert(chainlink_lrd.answer) * 10**18 / CHAINLINK_PRICE_PRECISION_ETH
-        #         lower = chainlink_p * (10**18 - BOUND_SIZE) / 10**18
-        #         upper = chainlink_p * (10**18 + BOUND_SIZE) / 10**18
-        #         crv_p = min(max(crv_p, lower), upper)
-
-        return int(p_staked * crv_p // 10**18)
-
-    def raw_price(self, p_staked: int = 10**18, **kwargs) -> int:
-        return self._raw_price(
-            self._ema_tvl(), self.stable_aggregator.price(), p_staked, **kwargs
-        )
-
-    def price_w(self, p_staked: int = 10**18, **kwargs) -> int:
-        tvls = self._ema_tvl()
-        if self.last_timestamp < self._block_timestamp:
-            self.last_timestamp = self._block_timestamp
-            self.last_tvl = tvls
-        return self._raw_price(
-            tvls, self.stable_aggregator.price_w(), p_staked, **kwargs
-        )
+    def update_staked_oracle(self, new: int) -> None:
+        """Update the staked oracle price."""
+        self.staked_oracle.update(new)

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/sfrxeth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/sfrxeth.py
@@ -21,7 +21,7 @@ class OracleSFRXETH(Oracle):
         (e.g. ETH -> sfrxETH).
         """
         crv_p = super()._raw_price(tvls, agg_price, *args, **kwargs)
-        crv_p = int(self.staked_oracle.price * crv_p // 10**18)
+        crv_p = int(self.staked_oracle.price * crv_p // PRECISION)
         self.last_price = crv_p
         return crv_p
 

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/tbtc.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/tbtc.py
@@ -7,8 +7,6 @@ from ... import ControllerFactory
 from ...utils import BlocktimestampMixins
 from ...stablecoin import StableCoin
 
-PRECISION = 10**18
-
 
 class OracleTBTC(Oracle):
     """

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/tbtc.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/tbtc.py
@@ -1,4 +1,5 @@
 """Provides the TBTC price oracle."""
+from typing import List
 from curvesim.pool.sim_interface import SimCurveCryptoPool
 from .base import Oracle
 from ..aggregate_stable_price import AggregateStablePrice
@@ -9,11 +10,11 @@ from ...stablecoin import StableCoin
 PRECISION = 10**18
 
 
-class OracleTBTC(Oracle, BlocktimestampMixins):
+class OracleTBTC(Oracle):
     def __init__(
         self,
-        tricrypto: SimCurveCryptoPool,
-        ix: int,  # 0 = TBTC
+        tricrypto: List[SimCurveCryptoPool],
+        ix: List[int],  # 0 = TBTC
         stable_aggregator: AggregateStablePrice,
         factory: ControllerFactory,
         # chainlink_aggregator_eth: ChainlinkAggregator,
@@ -21,16 +22,19 @@ class OracleTBTC(Oracle, BlocktimestampMixins):
         n_pools=1,
         **kwargs,
     ) -> None:
-        super(BlocktimestampMixins, self).__init__()
+        BlocktimestampMixins.__init__(self)
         # Turn into list for compatibility with parent class
-        self.tricrypto = [tricrypto]
-        self.tricrypto_ix = [ix]
+        self.tricrypto = tricrypto
+        self.tricrypto_ix = ix
         self.stable_aggregator = stable_aggregator
         self.factory = factory
         self._stablecoin: StableCoin = stable_aggregator.STABLECOIN
         self.n_pools = n_pools
         assert (
-            tricrypto.coin_addresses[0].lower() == self._stablecoin
+            tricrypto[0].coin_addresses[0].lower() == self._stablecoin.address.lower()
+        ), (
+            tricrypto[0].coin_addresses[0].lower(),
+            self._stablecoin.address.lower(),
         )  # TriCryptoLLAMMA has crvUSD as first coin
 
         # self.use_chainlink = True

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/tbtc.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/tbtc.py
@@ -11,6 +11,10 @@ PRECISION = 10**18
 
 
 class OracleTBTC(Oracle):
+    """
+    TBTC Oracle. Overrides most base Oracle functionality.
+    """
+
     def __init__(
         self,
         tricrypto: List[SimCurveCryptoPool],
@@ -42,7 +46,7 @@ class OracleTBTC(Oracle):
         # CHAINLINK_PRICE_PRECISION_BTC = 10**convert(chainlink_aggregator_btc.decimals(), uint256)
         # BOUND_SIZE = bound_size
 
-    def _raw_price(self, agg_price: int, **kwargs) -> int:
+    def _raw_price(self, agg_price: int, *args, **kwargs) -> int:
         p_crypto_stable = self.tricrypto[0].price_oracle()[
             self.tricrypto_ix[0]
         ]  # d_crvusd/d_tbtc

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/tbtc.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/tbtc.py
@@ -1,0 +1,63 @@
+"""Provides the TBTC price oracle."""
+from curvesim.pool.sim_interface import SimCurveCryptoPool
+from .base import Oracle
+from ..aggregate_stable_price import AggregateStablePrice
+from ... import ControllerFactory
+from ...utils import BlocktimestampMixins
+from ...stablecoin import StableCoin
+
+PRECISION = 10**18
+
+
+class OracleTBTC(Oracle, BlocktimestampMixins):
+    def __init__(
+        self,
+        tricrypto: SimCurveCryptoPool,
+        ix: int,  # 0 = TBTC
+        stable_aggregator: AggregateStablePrice,
+        factory: ControllerFactory,
+        # chainlink_aggregator_eth: ChainlinkAggregator,
+        # bound_size: int,  # 1.5% sounds ok before we turn it off
+        n_pools=1,
+        **kwargs,
+    ) -> None:
+        super(BlocktimestampMixins, self).__init__()
+        # Turn into list for compatibility with parent class
+        self.tricrypto = [tricrypto]
+        self.tricrypto_ix = [ix]
+        self.stable_aggregator = stable_aggregator
+        self.factory = factory
+        self._stablecoin: StableCoin = stable_aggregator.STABLECOIN
+        self.n_pools = n_pools
+        assert (
+            tricrypto.coin_addresses[0].lower() == self._stablecoin
+        )  # TriCryptoLLAMMA has crvUSD as first coin
+
+        # self.use_chainlink = True
+        # CHAINLINK_AGGREGATOR_BTC = chainlink_aggregator_btc
+        # CHAINLINK_PRICE_PRECISION_BTC = 10**convert(chainlink_aggregator_btc.decimals(), uint256)
+        # BOUND_SIZE = bound_size
+
+    def _raw_price(self, agg_price: int, **kwargs) -> int:
+        p_crypto_stable = self.tricrypto[0].price_oracle()[
+            self.tricrypto_ix[0]
+        ]  # d_crvusd/d_tbtc
+        p_stable_agg = agg_price  # d_usd/d_crvusd
+        price = p_crypto_stable * p_stable_agg // 10**18  # d_usd/d_btc
+
+        # Limit BTC price
+        # if self.use_chainlink:
+        #     chainlink_lrd: ChainlinkAnswer = CHAINLINK_AGGREGATOR_BTC.latestRoundData()
+        #     if block.timestamp - min(chainlink_lrd.updated_at, block.timestamp) <= CHAINLINK_STALE_THRESHOLD:
+        #         chainlink_p = convert(chainlink_lrd.answer) * 10**18 / CHAINLINK_PRICE_PRECISION_BTC
+        #         lower = chainlink_p * (10**18 - BOUND_SIZE) / 10**18
+        #         upper = chainlink_p * (10**18 + BOUND_SIZE) / 10**18
+        #         price = min(max(price, lower), upper)
+
+        return int(price)
+
+    def raw_price(self, **kwargs) -> int:
+        return self._raw_price(self.stable_aggregator.price(), **kwargs)
+
+    def price_w(self, **kwargs) -> int:
+        return self._raw_price(self.stable_aggregator.price(), **kwargs)

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wbtc.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wbtc.py
@@ -1,8 +1,5 @@
 """Provides the WBTC price oracle."""
-from typing import List
 from .base import Oracle
-
-PRECISION = 10**18
 
 
 class OracleWBTC(Oracle):

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wbtc.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wbtc.py
@@ -1,0 +1,78 @@
+"""Provides the WBTC price oracle."""
+from typing import List
+from curvesim.pool.sim_interface import SimCurveCryptoPool
+from .base import Oracle
+from ..aggregate_stable_price import AggregateStablePrice
+from ... import ControllerFactory
+from ...utils import BlocktimestampMixins
+from ....sim_interface import SimCurveStableSwapPool
+
+PRECISION = 10**18
+
+
+class OracleWBTC(Oracle, BlocktimestampMixins):
+    def __init__(
+        self,
+        tricrypto: List[SimCurveCryptoPool],
+        ix: List[int],  # 0 = WBTC
+        stableswap: List[SimCurveStableSwapPool],
+        stable_aggregator: AggregateStablePrice,
+        factory: ControllerFactory,
+        # chainlink_aggregator_eth: ChainlinkAggregator,
+        # bound_size: int,  # 1.5% sounds ok before we turn it off
+        n_pools=2,
+        tvl_ma_time=50000,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            tricrypto,
+            ix,
+            stableswap,
+            stable_aggregator,
+            factory,
+            n_pools,
+            tvl_ma_time,
+            **kwargs,
+        )
+
+    def _raw_price(self, tvls: List[int], agg_price: int, **kwargs) -> int:
+        weighted_price = 0
+        weights = 0
+        for i in range(self.n_pools):
+            p_crypto_r = self.tricrypto[i].price_oracle()[
+                self.tricrypto_ix[i]
+            ]  # d_usdt/d_eth
+            p_stable_r = self.stableswap[i].price_oracle()  # d_usdt/d_st
+            p_stable_agg = agg_price  # d_usd/d_st
+            if self._is_inverse[i]:
+                p_stable_r = 10**36 // p_stable_r
+            weight = tvls[i]
+            # Prices are already EMA but weights - not so much
+            weights += weight
+            weighted_price += (
+                p_crypto_r * p_stable_agg // p_stable_r * weight
+            )  # d_usd/d_eth
+        crv_p = weighted_price // weights
+
+        # Limit BTC price
+        # if self.use_chainlink:
+        #     chainlink_lrd: ChainlinkAnswer = CHAINLINK_AGGREGATOR_ETH.latestRoundData()
+        #     if block.timestamp - min(chainlink_lrd.updated_at, block.timestamp) <= CHAINLINK_STALE_THRESHOLD:
+        #         chainlink_p = convert(chainlink_lrd.answer, uint256) * PRECISION / CHAINLINK_PRICE_PRECISION_ETH
+        #         lower = chainlink_p * (PRECISION - BOUND_SIZE) / PRECISION
+        #         upper = chainlink_p * (PRECISION + BOUND_SIZE) / PRECISION
+        #         crv_p = min(max(crv_p, lower), upper)
+
+        return int(crv_p)
+
+    def raw_price(self, **kwargs) -> int:
+        return self._raw_price(
+            self._ema_tvl(), self.stable_aggregator.price(), **kwargs
+        )
+
+    def price_w(self, **kwargs) -> int:
+        tvls = self._ema_tvl()
+        if self.last_timestamp < self._block_timestamp:
+            self.last_timestamp = self._block_timestamp
+            self.last_tvl = tvls
+        return self._raw_price(tvls, self.stable_aggregator.price_w(), **kwargs)

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wbtc.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wbtc.py
@@ -6,44 +6,7 @@ PRECISION = 10**18
 
 
 class OracleWBTC(Oracle):
-    def _raw_price(self, tvls: List[int], agg_price: int, **kwargs) -> int:
-        weighted_price = 0
-        weights = 0
-        for i in range(self.n_pools):
-            p_crypto_r = self.tricrypto[i].price_oracle()[
-                self.tricrypto_ix[i]
-            ]  # d_usdt/d_eth
-            p_stable_r = self.stableswap[i].price_oracle()  # d_usdt/d_st
-            p_stable_agg = agg_price  # d_usd/d_st
-            if self._is_inverse[i]:
-                p_stable_r = 10**36 // p_stable_r
-            weight = tvls[i]
-            # Prices are already EMA but weights - not so much
-            weights += weight
-            weighted_price += (
-                p_crypto_r * p_stable_agg // p_stable_r * weight
-            )  # d_usd/d_eth
-        crv_p = weighted_price // weights
-
-        # Limit BTC price
-        # if self.use_chainlink:
-        #     chainlink_lrd: ChainlinkAnswer = CHAINLINK_AGGREGATOR_ETH.latestRoundData()
-        #     if block.timestamp - min(chainlink_lrd.updated_at, block.timestamp) <= CHAINLINK_STALE_THRESHOLD:
-        #         chainlink_p = convert(chainlink_lrd.answer, uint256) * PRECISION / CHAINLINK_PRICE_PRECISION_ETH
-        #         lower = chainlink_p * (PRECISION - BOUND_SIZE) / PRECISION
-        #         upper = chainlink_p * (PRECISION + BOUND_SIZE) / PRECISION
-        #         crv_p = min(max(crv_p, lower), upper)
-
-        return int(crv_p)
-
-    def raw_price(self, **kwargs) -> int:
-        return self._raw_price(
-            self._ema_tvl(), self.stable_aggregator.price(), **kwargs
-        )
-
-    def price_w(self, **kwargs) -> int:
-        tvls = self._ema_tvl()
-        if self.last_timestamp < self._block_timestamp:
-            self.last_timestamp = self._block_timestamp
-            self.last_tvl = tvls
-        return self._raw_price(tvls, self.stable_aggregator.price_w(), **kwargs)
+    """
+    WBTC Price oracle.
+    Currently matches the base implementation
+    """

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wbtc.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wbtc.py
@@ -1,40 +1,11 @@
 """Provides the WBTC price oracle."""
 from typing import List
-from curvesim.pool.sim_interface import SimCurveCryptoPool
 from .base import Oracle
-from ..aggregate_stable_price import AggregateStablePrice
-from ... import ControllerFactory
-from ...utils import BlocktimestampMixins
-from ....sim_interface import SimCurveStableSwapPool
 
 PRECISION = 10**18
 
 
-class OracleWBTC(Oracle, BlocktimestampMixins):
-    def __init__(
-        self,
-        tricrypto: List[SimCurveCryptoPool],
-        ix: List[int],  # 0 = WBTC
-        stableswap: List[SimCurveStableSwapPool],
-        stable_aggregator: AggregateStablePrice,
-        factory: ControllerFactory,
-        # chainlink_aggregator_eth: ChainlinkAggregator,
-        # bound_size: int,  # 1.5% sounds ok before we turn it off
-        n_pools=2,
-        tvl_ma_time=50000,
-        **kwargs,
-    ) -> None:
-        super().__init__(
-            tricrypto,
-            ix,
-            stableswap,
-            stable_aggregator,
-            factory,
-            n_pools,
-            tvl_ma_time,
-            **kwargs,
-        )
-
+class OracleWBTC(Oracle):
     def _raw_price(self, tvls: List[int], agg_price: int, **kwargs) -> int:
         weighted_price = 0
         weights = 0

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/weth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/weth.py
@@ -1,8 +1,5 @@
 """Provides the WETH price oracle."""
-from typing import List
 from .base import Oracle
-
-PRECISION = 10**18
 
 
 class OracleWETH(Oracle):

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/weth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/weth.py
@@ -1,40 +1,11 @@
 """Provides the WETH price oracle."""
 from typing import List
-from curvesim.pool.sim_interface import SimCurveCryptoPool
 from .base import Oracle
-from ..aggregate_stable_price import AggregateStablePrice
-from ... import ControllerFactory
-from ...utils import BlocktimestampMixins
-from ....sim_interface import SimCurveStableSwapPool
 
 PRECISION = 10**18
 
 
-class OracleWETH(Oracle, BlocktimestampMixins):
-    def __init__(
-        self,
-        tricrypto: List[SimCurveCryptoPool],
-        ix: List[int],  # 1 = ETH
-        stableswap: List[SimCurveStableSwapPool],
-        stable_aggregator: AggregateStablePrice,
-        factory: ControllerFactory,
-        # chainlink_aggregator_eth: ChainlinkAggregator,
-        # bound_size: int,  # 1.5% sounds ok before we turn it off
-        n_pools=2,
-        tvl_ma_time=50000,
-        **kwargs,
-    ) -> None:
-        super().__init__(
-            tricrypto,
-            ix,
-            stableswap,
-            stable_aggregator,
-            factory,
-            n_pools,
-            tvl_ma_time,
-            **kwargs,
-        )
-
+class OracleWETH(Oracle):
     def _raw_price(self, tvls: List[int], agg_price: int, **kwargs) -> int:
         weighted_price = 0
         weights = 0

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/weth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/weth.py
@@ -6,44 +6,7 @@ PRECISION = 10**18
 
 
 class OracleWETH(Oracle):
-    def _raw_price(self, tvls: List[int], agg_price: int, **kwargs) -> int:
-        weighted_price = 0
-        weights = 0
-        for i in range(self.n_pools):
-            p_crypto_r = self.tricrypto[i].price_oracle()[
-                self.tricrypto_ix[i]
-            ]  # d_usdt/d_eth
-            p_stable_r = self.stableswap[i].price_oracle()  # d_usdt/d_st
-            p_stable_agg = agg_price  # d_usd/d_st
-            if self._is_inverse[i]:
-                p_stable_r = 10**36 // p_stable_r
-            weight = tvls[i]
-            # Prices are already EMA but weights - not so much
-            weights += weight
-            weighted_price += (
-                p_crypto_r * p_stable_agg // p_stable_r * weight
-            )  # d_usd/d_eth
-        crv_p = weighted_price // weights
-
-        # Limit WETH price
-        # if self.use_chainlink:
-        #     chainlink_lrd: ChainlinkAnswer = CHAINLINK_AGGREGATOR_ETH.latestRoundData()
-        #     if block.timestamp - min(chainlink_lrd.updated_at, block.timestamp) <= CHAINLINK_STALE_THRESHOLD:
-        #         chainlink_p = convert(chainlink_lrd.answer, uint256) * PRECISION / CHAINLINK_PRICE_PRECISION_ETH
-        #         lower = chainlink_p * (PRECISION - BOUND_SIZE) / PRECISION
-        #         upper = chainlink_p * (PRECISION + BOUND_SIZE) / PRECISION
-        #         crv_p = min(max(crv_p, lower), upper)
-
-        return int(crv_p)
-
-    def raw_price(self, **kwargs) -> int:
-        return self._raw_price(
-            self._ema_tvl(), self.stable_aggregator.price(), **kwargs
-        )
-
-    def price_w(self, **kwargs) -> int:
-        tvls = self._ema_tvl()
-        if self.last_timestamp < self._block_timestamp:
-            self.last_timestamp = self._block_timestamp
-            self.last_tvl = tvls
-        return self._raw_price(tvls, self.stable_aggregator.price_w(), **kwargs)
+    """
+    WETH Price oracle.
+    Currently matches the base implementation
+    """

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/weth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/weth.py
@@ -1,0 +1,78 @@
+"""Provides the WETH price oracle."""
+from typing import List
+from curvesim.pool.sim_interface import SimCurveCryptoPool
+from .base import Oracle
+from ..aggregate_stable_price import AggregateStablePrice
+from ... import ControllerFactory
+from ...utils import BlocktimestampMixins
+from ....sim_interface import SimCurveStableSwapPool
+
+PRECISION = 10**18
+
+
+class OracleWETH(Oracle, BlocktimestampMixins):
+    def __init__(
+        self,
+        tricrypto: List[SimCurveCryptoPool],
+        ix: List[int],  # 1 = ETH
+        stableswap: List[SimCurveStableSwapPool],
+        stable_aggregator: AggregateStablePrice,
+        factory: ControllerFactory,
+        # chainlink_aggregator_eth: ChainlinkAggregator,
+        # bound_size: int,  # 1.5% sounds ok before we turn it off
+        n_pools=2,
+        tvl_ma_time=50000,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            tricrypto,
+            ix,
+            stableswap,
+            stable_aggregator,
+            factory,
+            n_pools,
+            tvl_ma_time,
+            **kwargs,
+        )
+
+    def _raw_price(self, tvls: List[int], agg_price: int, **kwargs) -> int:
+        weighted_price = 0
+        weights = 0
+        for i in range(self.n_pools):
+            p_crypto_r = self.tricrypto[i].price_oracle()[
+                self.tricrypto_ix[i]
+            ]  # d_usdt/d_eth
+            p_stable_r = self.stableswap[i].price_oracle()  # d_usdt/d_st
+            p_stable_agg = agg_price  # d_usd/d_st
+            if self._is_inverse[i]:
+                p_stable_r = 10**36 // p_stable_r
+            weight = tvls[i]
+            # Prices are already EMA but weights - not so much
+            weights += weight
+            weighted_price += (
+                p_crypto_r * p_stable_agg // p_stable_r * weight
+            )  # d_usd/d_eth
+        crv_p = weighted_price // weights
+
+        # Limit WETH price
+        # if self.use_chainlink:
+        #     chainlink_lrd: ChainlinkAnswer = CHAINLINK_AGGREGATOR_ETH.latestRoundData()
+        #     if block.timestamp - min(chainlink_lrd.updated_at, block.timestamp) <= CHAINLINK_STALE_THRESHOLD:
+        #         chainlink_p = convert(chainlink_lrd.answer, uint256) * PRECISION / CHAINLINK_PRICE_PRECISION_ETH
+        #         lower = chainlink_p * (PRECISION - BOUND_SIZE) / PRECISION
+        #         upper = chainlink_p * (PRECISION + BOUND_SIZE) / PRECISION
+        #         crv_p = min(max(crv_p, lower), upper)
+
+        return int(crv_p)
+
+    def raw_price(self, **kwargs) -> int:
+        return self._raw_price(
+            self._ema_tvl(), self.stable_aggregator.price(), **kwargs
+        )
+
+    def price_w(self, **kwargs) -> int:
+        tvls = self._ema_tvl()
+        if self.last_timestamp < self._block_timestamp:
+            self.last_timestamp = self._block_timestamp
+            self.last_tvl = tvls
+        return self._raw_price(tvls, self.stable_aggregator.price_w(), **kwargs)

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wsteth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wsteth.py
@@ -1,42 +1,13 @@
 """Provides the wstETH price oracle."""
 from typing import List
-from curvesim.pool.sim_interface import SimCurveCryptoPool
 from .base import Oracle
-from ..aggregate_stable_price import AggregateStablePrice
-from ... import ControllerFactory
-from ...utils import BlocktimestampMixins, ERC20
-from ....sim_interface import SimCurveStableSwapPool
 
 PRECISION = 10**18
 
 
-class OracleWSTETH(Oracle, BlocktimestampMixins):
-    def __init__(
-        self,
-        tricrypto: List[SimCurveCryptoPool],
-        ix: List[int],  # 0 = WBTC
-        stableswap: List[SimCurveStableSwapPool],
-        stable_aggregator: AggregateStablePrice,
-        factory: ControllerFactory,
-        # chainlink_aggregator_eth: ChainlinkAggregator,
-        # bound_size: int,  # 1.5% sounds ok before we turn it off
-        n_pools=2,
-        tvl_ma_time=50000,
-        **kwargs,
-    ) -> None:
-        super().__init__(
-            tricrypto,
-            ix,
-            stableswap,
-            stable_aggregator,
-            factory,
-            n_pools,
-            tvl_ma_time,
-            **kwargs,
-        )
-
+class OracleWSTETH(Oracle):
     def _raw_price(
-        self, tvls: List[int], agg_price: int, p_staked: int, **kwargs
+        self, tvls: List[int], agg_price: int, p_staked: int = 10**18, **kwargs
     ) -> int:
         """
         Get the price of the underlying asset from TriCrypto and StableSwap
@@ -75,12 +46,12 @@ class OracleWSTETH(Oracle, BlocktimestampMixins):
 
         return int(p_staked * crv_p // 10**18)
 
-    def raw_price(self, p_staked, **kwargs) -> int:
+    def raw_price(self, p_staked: int = 10**18, **kwargs) -> int:
         return self._raw_price(
             self._ema_tvl(), self.stable_aggregator.price(), p_staked, **kwargs
         )
 
-    def price_w(self, p_staked, **kwargs) -> int:
+    def price_w(self, p_staked: int = 10**18, **kwargs) -> int:
         tvls = self._ema_tvl()
         if self.last_timestamp < self._block_timestamp:
             self.last_timestamp = self._block_timestamp

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wsteth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wsteth.py
@@ -1,61 +1,28 @@
 """Provides the wstETH price oracle."""
 from typing import List
-from .base import Oracle
+from .base import Oracle, StakedOracle
 
 PRECISION = 10**18
 
 
 class OracleWSTETH(Oracle):
-    def _raw_price(
-        self, tvls: List[int], agg_price: int, p_staked: int = 10**18, **kwargs
-    ) -> int:
+    """Oracle for sfrxETH"""
+
+    def __init__(self, staked_oracle: StakedOracle | None = None, **kwargs):
+        super().__init__(**kwargs)
+        self.staked_oracle = staked_oracle or StakedOracle()
+
+    def _raw_price(self, tvls: List[int], agg_price: int, *args, **kwargs) -> int:
         """
         Get the price of the underlying asset from TriCrypto and StableSwap
         pools (e.g. ETH price).
 
-        Convert this price to the staked asset price using the given p_staked
-        (e.g. ETH -> wstETH).
+        Convert this price to the staked asset price using staked oracle price.
+        (e.g. ETH -> sfrxETH).
         """
-        weighted_price = 0
-        weights = 0
-        for i in range(self.n_pools):
-            p_crypto_r = self.tricrypto[i].price_oracle()[
-                self.tricrypto_ix[i]
-            ]  # d_usdt/d_eth
-            p_stable_r = self.stableswap[i].price_oracle()  # d_usdt/d_crvusd
-            p_stable_agg = agg_price  # d_usd/d_crvusd
-            if self._is_inverse[i]:
-                p_stable_r = 10**36 // p_stable_r
-            weight = tvls[i]
-            weights += weight
-            weighted_price += (
-                p_crypto_r * p_stable_agg // p_stable_r * weight
-            )  # d_usd/d_eth
-        crv_p = weighted_price // weights
+        crv_p = super()._raw_price(tvls, agg_price, *args, **kwargs)
+        return int(self.staked_oracle.price * crv_p // 10**18)
 
-        # use_chainlink: bool = self.use_chainlink
-
-        # # Limit ETH price
-        # if use_chainlink:
-        #     chainlink_lrd: ChainlinkAnswer = CHAINLINK_AGGREGATOR_ETH.latestRoundData()
-        #     if block.timestamp - min(chainlink_lrd.updated_at, block.timestamp) <= CHAINLINK_STALE_THRESHOLD:
-        #         chainlink_p = convert(chainlink_lrd.answer) * 10**18 / CHAINLINK_PRICE_PRECISION_ETH
-        #         lower = chainlink_p * (10**18 - BOUND_SIZE) / 10**18
-        #         upper = chainlink_p * (10**18 + BOUND_SIZE) / 10**18
-        #         crv_p = min(max(crv_p, lower), upper)
-
-        return int(p_staked * crv_p // 10**18)
-
-    def raw_price(self, p_staked: int = 10**18, **kwargs) -> int:
-        return self._raw_price(
-            self._ema_tvl(), self.stable_aggregator.price(), p_staked, **kwargs
-        )
-
-    def price_w(self, p_staked: int = 10**18, **kwargs) -> int:
-        tvls = self._ema_tvl()
-        if self.last_timestamp < self._block_timestamp:
-            self.last_timestamp = self._block_timestamp
-            self.last_tvl = tvls
-        return self._raw_price(
-            tvls, self.stable_aggregator.price_w(), p_staked, **kwargs
-        )
+    def update_staked_oracle(self, new: int) -> None:
+        """Update the staked oracle price."""
+        self.staked_oracle.update(new)

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wsteth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wsteth.py
@@ -1,0 +1,90 @@
+"""Provides the wstETH price oracle."""
+from typing import List
+from curvesim.pool.sim_interface import SimCurveCryptoPool
+from .base import Oracle
+from ..aggregate_stable_price import AggregateStablePrice
+from ... import ControllerFactory
+from ...utils import BlocktimestampMixins, ERC20
+from ....sim_interface import SimCurveStableSwapPool
+
+PRECISION = 10**18
+
+
+class OracleWSTETH(Oracle, BlocktimestampMixins):
+    def __init__(
+        self,
+        tricrypto: List[SimCurveCryptoPool],
+        ix: List[int],  # 0 = WBTC
+        stableswap: List[SimCurveStableSwapPool],
+        stable_aggregator: AggregateStablePrice,
+        factory: ControllerFactory,
+        # chainlink_aggregator_eth: ChainlinkAggregator,
+        # bound_size: int,  # 1.5% sounds ok before we turn it off
+        n_pools=2,
+        tvl_ma_time=50000,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            tricrypto,
+            ix,
+            stableswap,
+            stable_aggregator,
+            factory,
+            n_pools,
+            tvl_ma_time,
+            **kwargs,
+        )
+
+    def _raw_price(
+        self, tvls: List[int], agg_price: int, p_staked: int, **kwargs
+    ) -> int:
+        """
+        Get the price of the underlying asset from TriCrypto and StableSwap
+        pools (e.g. ETH price).
+
+        Convert this price to the staked asset price using the given p_staked
+        (e.g. ETH -> wstETH).
+        """
+        weighted_price = 0
+        weights = 0
+        for i in range(self.n_pools):
+            p_crypto_r = self.tricrypto[i].price_oracle()[
+                self.tricrypto_ix[i]
+            ]  # d_usdt/d_eth
+            p_stable_r = self.stableswap[i].price_oracle()  # d_usdt/d_crvusd
+            p_stable_agg = agg_price  # d_usd/d_crvusd
+            if self._is_inverse[i]:
+                p_stable_r = 10**36 // p_stable_r
+            weight = tvls[i]
+            weights += weight
+            weighted_price += (
+                p_crypto_r * p_stable_agg // p_stable_r * weight
+            )  # d_usd/d_eth
+        crv_p = weighted_price // weights
+
+        # use_chainlink: bool = self.use_chainlink
+
+        # # Limit ETH price
+        # if use_chainlink:
+        #     chainlink_lrd: ChainlinkAnswer = CHAINLINK_AGGREGATOR_ETH.latestRoundData()
+        #     if block.timestamp - min(chainlink_lrd.updated_at, block.timestamp) <= CHAINLINK_STALE_THRESHOLD:
+        #         chainlink_p = convert(chainlink_lrd.answer) * 10**18 / CHAINLINK_PRICE_PRECISION_ETH
+        #         lower = chainlink_p * (10**18 - BOUND_SIZE) / 10**18
+        #         upper = chainlink_p * (10**18 + BOUND_SIZE) / 10**18
+        #         crv_p = min(max(crv_p, lower), upper)
+
+        return int(p_staked * crv_p // 10**18)
+
+    def raw_price(self, p_staked, **kwargs) -> int:
+        return self._raw_price(
+            self._ema_tvl(), self.stable_aggregator.price(), p_staked, **kwargs
+        )
+
+    def price_w(self, p_staked, **kwargs) -> int:
+        tvls = self._ema_tvl()
+        if self.last_timestamp < self._block_timestamp:
+            self.last_timestamp = self._block_timestamp
+            self.last_tvl = tvls
+        return self._raw_price(
+            tvls, self.stable_aggregator.price_w(), p_staked, **kwargs
+        )

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wsteth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wsteth.py
@@ -21,7 +21,7 @@ class OracleWSTETH(Oracle):
         (e.g. ETH -> sfrxETH).
         """
         crv_p = super()._raw_price(tvls, agg_price, *args, **kwargs)
-        crv_p = int(self.staked_oracle.price * crv_p // 10**18)
+        crv_p = int(self.staked_oracle.price * crv_p // PRECISION)
         self.last_price = crv_p
         return crv_p
 

--- a/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wsteth.py
+++ b/crvusdsim/pool/crvusd/price_oracle/crypto_with_stable_price/wsteth.py
@@ -21,7 +21,9 @@ class OracleWSTETH(Oracle):
         (e.g. ETH -> sfrxETH).
         """
         crv_p = super()._raw_price(tvls, agg_price, *args, **kwargs)
-        return int(self.staked_oracle.price * crv_p // 10**18)
+        crv_p = int(self.staked_oracle.price * crv_p // 10**18)
+        self.last_price = crv_p
+        return crv_p
 
     def update_staked_oracle(self, new: int) -> None:
         """Update the staked oracle price."""

--- a/crvusdsim/pool/crvusd/stableswap.py
+++ b/crvusdsim/pool/crvusd/stableswap.py
@@ -616,7 +616,7 @@ class CurveStableSwapPool(Pool, BlocktimestampMixins):
         old_balances: List[int] = self.balances.copy()
         D0: int = self.get_D_mem(rates, old_balances, amp)
 
-        new_balances: List[int] = old_balances
+        new_balances: List[int] = old_balances.copy()
         for i in range(self.n):
             amount: int = _amounts[i]
             if amount != 0:

--- a/crvusdsim/pool/crvusd/stableswap.py
+++ b/crvusdsim/pool/crvusd/stableswap.py
@@ -901,7 +901,7 @@ class CurveStableSwapPool(Pool, BlocktimestampMixins):
         D0: int = self.get_D_mem(rates, old_balances, amp)
 
         total_supply: int = self.totalSupply
-        new_balances: List[int] = old_balances
+        new_balances: List[int] = old_balances.copy()
         for i in range(self.n):
             amount: int = _amounts[i]
             if _is_deposit:

--- a/crvusdsim/pool_data/metadata/market.py
+++ b/crvusdsim/pool_data/metadata/market.py
@@ -76,9 +76,15 @@ class MarketMetaData(PoolMetaDataBase):
             bands_y = defaultdict(int)
 
             for b in data["llamma_params"]["bands_x"]:
-                bands_x[int(b)] = int(data["llamma_params"]["bands_x"][b])
-            for b in data["llamma_params"]["bands_y"]:
-                bands_y[int(b)] = int(data["llamma_params"]["bands_y"][b])
+                b = int(b)
+                b_x = int(data["llamma_params"]["bands_x"][b])
+                b_y = int(data["llamma_params"]["bands_y"][b])
+                bands_x[b] = b_x
+                bands_y[b] = b_y
+                # override active_band since bands data is 
+                # snapshot at a different time
+                if b_x > 0 and b_y > 0:
+                    pool_kwargs["active_band"] = b  
 
             pool_kwargs["bands_x"] = bands_x
             pool_kwargs["bands_y"] = bands_y

--- a/crvusdsim/pool_data/metadata/market.py
+++ b/crvusdsim/pool_data/metadata/market.py
@@ -126,12 +126,10 @@ class MarketMetaData(PoolMetaDataBase):
                     if broken_user:
                         continue
 
-                    # As in Vyper code, user shares reflect their deposited
-                    # collateral in a band.
                     for b_i in range(n1, n2 + 1):
-                        deposited_collateral = format_float_to_uint256(_u["depositedCollateral"]) // N
-                        total_shares[b_i] += deposited_collateral
-                        ticks.append(deposited_collateral)
+                        collateral_up = format_float_to_uint256(_u["collateralUp"]) // N
+                        total_shares[b_i] += collateral_up
+                        ticks.append(collateral_up)
 
                     user_shares[user_address] = UserShares(n1,n2,ticks)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,7 @@ from crvusdsim.pool.crvusd.price_oracle.aggregate_stable_price import (
     AggregateStablePrice,
 )
 from crvusdsim.pool.crvusd.price_oracle.price_oracle import PriceOracle
-from crvusdsim.pool.crvusd.price_oracle.crypto_with_stable_price import (
+from crvusdsim.pool.crvusd.price_oracle.weth import (
     CryptoWithStablePrice
 )
 from crvusdsim.pool.crvusd.stabilizer.peg_keeper import PegKeeper

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@ from typing import Tuple
 import pytest
 from math import log
 
+from curvesim.pool.sim_interface import SimCurveCryptoPool
 from crvusdsim.pool.crvusd.conf import ARBITRAGUR_ADDRESS
 from crvusdsim.pool.crvusd.utils.ERC20 import ERC20
 from crvusdsim.pool.crvusd.LLAMMA import LLAMMAPool
@@ -12,9 +13,13 @@ from crvusdsim.pool.crvusd.price_oracle.aggregate_stable_price import (
     AggregateStablePrice,
 )
 from crvusdsim.pool.crvusd.price_oracle.price_oracle import PriceOracle
+from crvusdsim.pool.crvusd.price_oracle.crypto_with_stable_price import (
+    CryptoWithStablePrice
+)
 from crvusdsim.pool.crvusd.stabilizer.peg_keeper import PegKeeper
 from crvusdsim.pool.crvusd.stableswap import LP_PROVIDER, CurveStableSwapPool
 from crvusdsim.pool.crvusd.stablecoin import StableCoin
+from crvusdsim.pool.sim_interface import SimCurveStableSwapPool
 
 INIT_PRICE = 2000 * 10**18
 INIT_PRICE_D1 = INIT_PRICE // 10**18
@@ -49,10 +54,51 @@ PEG_KEEPER_CALLER_SHARE = 2 * 10**4
 PEG_KEEPER_RECEIVER = "PEG_KEEPER_RECEIVER"
 PEG_KEEPER_ADMIN = "PEG_KEEPER_ADMIN"
 INIT_PEG_KEEPER_CEILING = MARKET_DEBT_CEILING // len(STABLE_COINS)
-
+# TriCrypto
+TRICRYPTO_COINS = [["USDC", "WBTC", "WETH"], ["USDT", "WBTC", "WETH"]]
+TRICRYPTO_A = 1707629
+TRICRYPTO_PRECISIONS = [1, 1, 1]
+TRICRYPTO_GAMMA = 11809167828997
+TRICRYPTO_N_COINS = 3
+TRICRYPTO_MID_FEE = 3000000
+TRICRYPTO_OUT_FEE = 30000000
+TRICRYPTO_ALLOWED_EXTRA_PROFIT = 2000000000000
+TRICRYPTO_FEE_GAMMA = 500000000000000
+TRICRYPTO_ADJUSTMENT_STEP = 490000000000000
+TRICRYPTO_MA_HALF_TIME = 600
+TRICRYPTO_PRICE_SCALE = [44912882696470104260465, 2357733641392764512005]
+TRICRYPTO_BALANCES = [
+    25709017706486000000000000, 
+    567766370730000000000, 
+    10916847916467958574912
+]
+TRICRYPTO_KWARGS = {
+        "A": TRICRYPTO_A,
+        "gamma": TRICRYPTO_GAMMA,
+        "n": TRICRYPTO_N_COINS,
+        "precisions": TRICRYPTO_PRECISIONS,
+        "mid_fee": TRICRYPTO_MID_FEE,
+        "out_fee": TRICRYPTO_OUT_FEE,
+        "allowed_extra_profit": TRICRYPTO_ALLOWED_EXTRA_PROFIT,
+        "fee_gamma": TRICRYPTO_FEE_GAMMA,
+        "adjustment_step": TRICRYPTO_ADJUSTMENT_STEP,
+        "ma_half_time": TRICRYPTO_MA_HALF_TIME,
+        "price_scale": TRICRYPTO_PRICE_SCALE,
+        "balances": TRICRYPTO_BALANCES,
+}
 # Aggregator
 AGGREGATOR_SIGMA = 10**15
-
+# Crypto with Stable Price
+CRYPTO_WITH_STABLE_PRICE_N = 2
+CRYPTO_WITH_STABLE_PRICE_COINS = ["USDC", "USDT"]
+CRYPTO_WITH_STABLE_PRICE_IX = {
+    "weth": [1, 1],
+    "wbtc": [0, 0],
+}
+CRYPTO_WITH_STABLE_PRICE_COLLAT_IX = {
+    "weth": [2, 2],
+    "wbtc": [1, 1]
+} # TODO is this just ix + 1?
 
 def _create_stablecoin():
     coin = StableCoin()
@@ -63,11 +109,11 @@ def _create_stablecoin():
     return coin
 
 
-def _create_collteral():
+def _create_collteral(symbol = "wstETH"):
     coin = ERC20(
-        address="wstETH_address",
-        name="Wrapped stETH",
-        symbol="wstETH",
+        address="%s_address" % (symbol),
+        name="%s" % (symbol),
+        symbol=symbol,
         decimals=18,
     )
     coin._mint(LP_PROVIDER, 10**6 * 10**18)
@@ -75,26 +121,31 @@ def _create_collteral():
     return coin
 
 
-def _create_other_coins():
-    coins = []
-    for symbol in STABLE_COINS:
-        _coin = StableCoin(
-            address="%s_address" % (symbol),
-            symbol=symbol,
-            name="%s" % (symbol),
-            decimals=18,
-        )
-        _coin._mint(LP_PROVIDER, 10**6 * 10**18)
-        _coin._mint(ARBITRAGUR_ADDRESS, 10**6 * 10**18)
-        coins.append(_coin)
+def _create_other_stablecoin(symbol):
+    _coin = StableCoin(
+        address="%s_address" % (symbol),
+        symbol=symbol,
+        name="%s" % (symbol),
+        decimals=18,
+    )
+    _coin._mint(LP_PROVIDER, 10**6 * 10**18)
+    _coin._mint(ARBITRAGUR_ADDRESS, 10**6 * 10**18)
+    return _coin
 
+
+def _create_other_coins(other_coins=STABLE_COINS):
+    coins = []
+    for symbol in other_coins:
+        _coin = _create_other_stablecoin(symbol)
+        coins.append(_coin)
     return coins
 
 
-def _create_stableswaps(stablecoin, other_coins):
+def _create_stableswaps(stablecoin, other_coins, sim = False):
     pools = []
+    constructor = CurveStableSwapPool if not sim else SimCurveStableSwapPool
     for peg_coin in other_coins:
-        _pool = CurveStableSwapPool(
+        _pool = constructor(
             name="crvUSD/%s" % (peg_coin.symbol),
             symbol="crvUSD-%s" % (peg_coin.symbol),
             A=STABLE_A,
@@ -174,6 +225,42 @@ def create_amm():
     return amm, price_oracle
 
 
+def _create_tricrypto():
+    tricrypto = []
+    for coins in TRICRYPTO_COINS:
+        tpool = SimCurveCryptoPool(**TRICRYPTO_KWARGS)
+        coins = [
+            _create_other_stablecoin(symbol) 
+            if symbol in STABLE_COINS 
+            else _create_collteral(symbol) 
+            for symbol in coins
+        ]
+        tpool.metadata = {
+            "coins": {
+                "addresses": [c.address for c in coins]
+            }
+        }  # for `coin_addresses`
+        tricrypto.append(tpool)
+    return tricrypto
+
+
+def create_crypto_with_stable_price_oracle(market="weth"):
+    stablecoin = _create_stablecoin()
+    other_coins = _create_other_coins(CRYPTO_WITH_STABLE_PRICE_COINS)
+    factory = _create_factory(stablecoin)
+    stableswaps = _create_stableswaps(stablecoin, other_coins, sim=True)
+    aggregator = _create_aggregator(stablecoin, stableswaps)
+    tricrypto = _create_tricrypto()
+    ix = CRYPTO_WITH_STABLE_PRICE_IX[market]
+    return CryptoWithStablePrice(
+        tricrypto=tricrypto,
+        ix=ix,
+        stableswap=stableswaps,
+        stable_aggregator=aggregator,
+        factory=factory,
+    )
+
+
 def create_controller_amm():
     stablecoin = _create_stablecoin()
     other_coins = _create_other_coins()
@@ -251,3 +338,13 @@ def monetary_policy(price_oracle, pegkeepers, factory):
 @pytest.fixture(scope="module")
 def controller_and_amm():
     return create_controller_amm()
+
+
+@pytest.fixture(scope="module")
+def crypto_with_stable_price_oracle(market="weth"):
+    return create_crypto_with_stable_price_oracle(market)
+
+
+@pytest.fixture(scope="module")
+def tricrypto():
+    return _create_tricrypto()

--- a/test/oracle/test_crypto_with_stable_price.py
+++ b/test/oracle/test_crypto_with_stable_price.py
@@ -1,0 +1,45 @@
+from hypothesis import given
+from hypothesis import strategies as st
+from ..utils import trade
+from ..conftest import (
+    create_crypto_with_stable_price_oracle,
+    CRYPTO_WITH_STABLE_PRICE_N,
+    CRYPTO_WITH_STABLE_PRICE_COLLAT_IX,
+)
+
+@given(
+    frac=st.floats(min_value=0.1, max_value=0.9),
+    i=st.integers(min_value=0, max_value=CRYPTO_WITH_STABLE_PRICE_N - 1),
+    market=st.sampled_from(["weth", "wbtc"]),
+)
+def test_price_change_stableswap(frac, i, market):
+    oracle = create_crypto_with_stable_price_oracle(market)
+    price1 = oracle.price_w()
+
+    # Lower crvUSD price
+    price2 = trade(oracle, oracle.stableswap[i], 1, 0, frac)
+    assert price2 > price1
+
+    # Raise crvUSD price
+    price3 = trade(oracle, oracle.stableswap[i], 0, 1, frac)
+    assert price3 < price2
+
+
+@given(
+    frac=st.floats(min_value=0.1, max_value=0.9),
+    i=st.integers(min_value=0, max_value=CRYPTO_WITH_STABLE_PRICE_N - 1),
+    market=st.sampled_from(["weth", "wbtc"]),
+)
+def test_price_change_tricrypto(frac, i, market):
+    oracle = create_crypto_with_stable_price_oracle(market)
+    price1 = oracle.price_w()
+
+    ix = CRYPTO_WITH_STABLE_PRICE_COLLAT_IX[market][i]
+
+    # Lower collateral price
+    price2 = trade(oracle, oracle.tricrypto[i], ix, 0, frac)
+    assert price2 < price1
+
+    # Raise collateral price
+    price3 = trade(oracle, oracle.tricrypto[i], 0, ix, frac)
+    assert price3 > price2

--- a/test/utils/__init__.py
+++ b/test/utils/__init__.py
@@ -37,13 +37,3 @@ def generate_prices(price_max, price_min, trade_count, columns):
 def increment_timestamps(objects: List[Any], ts: int) -> None:
     for obj in objects:
         obj._increment_timestamp(ts)
-
-def trade(oracle, pool, i, j, frac):
-    amount = pool.get_max_trade_size(i, j, frac)
-    pool.exchange(i, j, amount)  # sell crvUSD for stablecoin
-
-    objects = oracle.stableswap + oracle.tricrypto + [oracle.stable_aggregator]
-    ts = oracle.last_timestamp + 60 * 60
-    increment_timestamps(objects, ts)
-
-    return oracle.price_w()

--- a/test/utils/__init__.py
+++ b/test/utils/__init__.py
@@ -1,3 +1,4 @@
+from typing import List, Any
 from datetime import datetime, timedelta
 from math import log
 import pandas as pd
@@ -32,3 +33,17 @@ def generate_prices(price_max, price_min, trade_count, columns):
 
     prices = pd.DataFrame(prices, columns=columns, index=ts_list)
     return prices
+
+def increment_timestamps(objects: List[Any], ts: int) -> None:
+    for obj in objects:
+        obj._increment_timestamp(ts)
+
+def trade(oracle, pool, i, j, frac):
+    amount = pool.get_max_trade_size(i, j, frac)
+    pool.exchange(i, j, amount)  # sell crvUSD for stablecoin
+
+    objects = oracle.stableswap + oracle.tricrypto + [oracle.stable_aggregator]
+    ts = oracle.last_timestamp + 60 * 60
+    increment_timestamps(objects, ts)
+
+    return oracle.price_w()


### PR DESCRIPTION
### Summary of Changes

Provide an oracle that points to the stableswap and tricrypto pools.

1. Implement the `crypto_with_stable_price` oracles. We implement a base `Oracle` class in `base.py`, we then implement the child oracles for each market. The WBTC and WETH markets use the base oracle with no modifications, the wstETH and sfrxETH markets multiply the base oracle price by the staked price (e.g. stETH/ETH price). The tBTC market implements a very different oracle. All implementations approximate the Vyper implementations. We add a feature to `freeze` and `unfreeze` oracle prices for simulation convenience.
2. Add option to override the simple `PriceOracle` in `get_sim_market`. This will call `get_oracle` for the given `LLAMMA`, which creates the necessary `TriCrypto` pools using `curvesim`. 
3. Add unit tests for the oracle. Test that oracle prices change as expected when a user trades against the StableSwap and TriCrypto pools.

### Tests

Passing.